### PR TITLE
fix(home): remove custom hybrid rail support

### DIFF
--- a/apps/sp-api/src/home/dto/create-home-rail.dto.ts
+++ b/apps/sp-api/src/home/dto/create-home-rail.dto.ts
@@ -14,7 +14,6 @@ import {
 import {
   HOME_RAIL_DIRECTION_VALUES,
   HOME_RAIL_FAVORITES_VALUES,
-  HOME_RAIL_LIBRARY_AVAILABILITY_VALUES,
   HOME_RAIL_SCENE_LIMIT_DEFAULT,
   HOME_RAIL_SCENE_LIMIT_MAX,
   HOME_RAIL_SCENE_LIMIT_MIN,
@@ -23,7 +22,6 @@ import {
   type HomeRailDirection,
   type HomeRailFavorites,
   type HomeRailSource,
-  type HomeRailLibraryAvailability,
   type HomeRailStashSceneSort,
   type HomeRailStashdbSceneSort,
   type HomeRailTagMode,
@@ -44,10 +42,6 @@ class HomeRailSceneConfigInputDto {
   @IsOptional()
   @IsIn(HOME_RAIL_FAVORITES_VALUES)
   favorites?: HomeRailFavorites | null;
-
-  @IsOptional()
-  @IsIn(HOME_RAIL_FAVORITES_VALUES)
-  stashdbFavorites?: HomeRailFavorites | null;
 
   @IsOptional()
   @IsArray()
@@ -87,25 +81,6 @@ class HomeRailSceneConfigInputDto {
   @Type(() => Boolean)
   @IsBoolean()
   favoriteTagsOnly?: boolean;
-
-  @IsOptional()
-  @Type(() => Boolean)
-  @IsBoolean()
-  stashFavoritePerformersOnly?: boolean;
-
-  @IsOptional()
-  @Type(() => Boolean)
-  @IsBoolean()
-  stashFavoriteStudiosOnly?: boolean;
-
-  @IsOptional()
-  @Type(() => Boolean)
-  @IsBoolean()
-  stashFavoriteTagsOnly?: boolean;
-
-  @IsOptional()
-  @IsIn(HOME_RAIL_LIBRARY_AVAILABILITY_VALUES)
-  libraryAvailability?: HomeRailLibraryAvailability;
 
   @Type(() => Number)
   @IsInt()

--- a/apps/sp-api/src/home/dto/home-rail.dto.ts
+++ b/apps/sp-api/src/home/dto/home-rail.dto.ts
@@ -19,7 +19,7 @@ export type HomeRailKey = (typeof HOME_RAIL_KEY_VALUES)[number];
 export const HOME_RAIL_KIND_VALUES = ['BUILTIN', 'CUSTOM'] as const;
 export type HomeRailKind = (typeof HOME_RAIL_KIND_VALUES)[number];
 
-export const HOME_RAIL_SOURCE_VALUES = ['STASHDB', 'STASH', 'HYBRID'] as const;
+export const HOME_RAIL_SOURCE_VALUES = ['STASHDB', 'STASH'] as const;
 export type HomeRailSource = (typeof HOME_RAIL_SOURCE_VALUES)[number];
 
 export const HOME_RAIL_CONTENT_TYPE_VALUES = ['SCENES'] as const;
@@ -44,12 +44,6 @@ export type HomeRailStashSceneSort = (typeof HOME_RAIL_STASH_SCENE_SORT_VALUES)[
 export type HomeRailDirection = SortDirection;
 export type HomeRailFavorites = SceneFavoritesFilter;
 export type HomeRailTagMode = SceneTagMatchMode;
-export const HOME_RAIL_LIBRARY_AVAILABILITY_VALUES = [
-  'IN_LIBRARY',
-  'MISSING_FROM_LIBRARY',
-] as const;
-export type HomeRailLibraryAvailability =
-  (typeof HOME_RAIL_LIBRARY_AVAILABILITY_VALUES)[number];
 
 export class HomeRailStashdbSceneConfigDto {
   sort!: HomeRailStashdbSceneSort;
@@ -78,26 +72,9 @@ export class HomeRailStashSceneConfigDto {
   limit!: number;
 }
 
-export class HomeRailHybridSceneConfigDto {
-  sort!: HomeRailStashdbSceneSort;
-  direction!: HomeRailDirection;
-  stashdbFavorites!: HomeRailFavorites | null;
-  tagIds!: string[];
-  tagNames!: string[];
-  tagMode!: HomeRailTagMode | null;
-  studioIds!: string[];
-  studioNames!: string[];
-  stashFavoritePerformersOnly!: boolean;
-  stashFavoriteStudiosOnly!: boolean;
-  stashFavoriteTagsOnly!: boolean;
-  libraryAvailability!: HomeRailLibraryAvailability;
-  limit!: number;
-}
-
 export type HomeRailSceneConfigDto =
   | HomeRailStashdbSceneConfigDto
-  | HomeRailStashSceneConfigDto
-  | HomeRailHybridSceneConfigDto;
+  | HomeRailStashSceneConfigDto;
 
 export class HomeRailDto {
   id!: string;

--- a/apps/sp-api/src/home/home-rail-hybrid.internal.ts
+++ b/apps/sp-api/src/home/home-rail-hybrid.internal.ts
@@ -1,0 +1,30 @@
+import type {
+  HomeRailDirection,
+  HomeRailFavorites,
+  HomeRailStashdbSceneSort,
+  HomeRailTagMode,
+} from './dto/home-rail.dto';
+
+export const LEGACY_HOME_RAIL_LIBRARY_AVAILABILITY_VALUES = [
+  'IN_LIBRARY',
+  'MISSING_FROM_LIBRARY',
+] as const;
+
+export type LegacyHomeRailLibraryAvailability =
+  (typeof LEGACY_HOME_RAIL_LIBRARY_AVAILABILITY_VALUES)[number];
+
+export interface LegacyHomeRailHybridSceneConfig {
+  sort: HomeRailStashdbSceneSort;
+  direction: HomeRailDirection;
+  stashdbFavorites: HomeRailFavorites | null;
+  tagIds: string[];
+  tagNames: string[];
+  tagMode: HomeRailTagMode | null;
+  studioIds: string[];
+  studioNames: string[];
+  stashFavoritePerformersOnly: boolean;
+  stashFavoriteStudiosOnly: boolean;
+  stashFavoriteTagsOnly: boolean;
+  libraryAvailability: LegacyHomeRailLibraryAvailability;
+  limit: number;
+}

--- a/apps/sp-api/src/home/home.service.spec.ts
+++ b/apps/sp-api/src/home/home.service.spec.ts
@@ -91,6 +91,7 @@ describe('HomeService', () => {
   const upsertMock = jest.fn();
   const findManyMock = jest.fn();
   const updateMock = jest.fn();
+  const updateManyMock = jest.fn();
   const transactionMock = jest.fn();
   const findFirstMock = jest.fn();
   const createMock = jest.fn();
@@ -113,6 +114,7 @@ describe('HomeService', () => {
       upsert: upsertMock,
       findMany: findManyMock,
       update: updateMock,
+      updateMany: updateManyMock,
       findFirst: findFirstMock,
       create: createMock,
       findUnique: findUniqueMock,
@@ -157,6 +159,7 @@ describe('HomeService', () => {
     transactionMock.mockImplementation((operations: Array<Promise<unknown>>) =>
       Promise.all(operations),
     );
+    updateManyMock.mockResolvedValue({ count: 0 });
     libraryGetScenesPreviewMock.mockResolvedValue([]);
     libraryGetScenesFeedMock.mockResolvedValue({
       total: 0,
@@ -187,7 +190,7 @@ describe('HomeService', () => {
     );
   });
 
-  it('bootstraps built-in rails and returns them in sort order', async () => {
+  it('bootstraps built-in rails, disables legacy hybrid rails, and returns supported rails in sort order', async () => {
     upsertMock.mockResolvedValue({});
     findManyMock.mockResolvedValue([
       buildRail({
@@ -220,7 +223,21 @@ describe('HomeService', () => {
     const result = await service.getRails();
 
     expect(upsertMock).toHaveBeenCalledTimes(3);
+    expect(updateManyMock).toHaveBeenCalledWith({
+      where: {
+        source: 'HYBRID',
+        enabled: true,
+      },
+      data: {
+        enabled: false,
+      },
+    });
     expect(findManyMock).toHaveBeenCalledWith({
+      where: {
+        source: {
+          not: 'HYBRID',
+        },
+      },
       orderBy: { sortOrder: 'asc' },
     });
     expect(result.map((rail) => rail.key)).toEqual([
@@ -387,85 +404,23 @@ describe('HomeService', () => {
     });
   });
 
-  it('creates a custom hybrid rail with explicit StashDB favorites and availability mode', async () => {
+  it('rejects creation of custom hybrid rails', async () => {
     upsertMock.mockResolvedValue({});
-    findFirstMock.mockResolvedValue(
-      buildStashRail({ id: 'built-in-3', sortOrder: 2 }),
-    );
-    createMock.mockResolvedValue(
-      buildHybridRail({
-        id: 'custom-hybrid-1',
-        title: 'Missing Favorite Studios',
-        subtitle: null,
-        sortOrder: 3,
+
+    await expect(
+      service.createRail({
+        source: 'HYBRID' as never,
+        title: ' Missing Favorite Studios ',
+        subtitle: '',
+        enabled: true,
         config: {
           sort: 'DATE',
           direction: 'DESC',
-          stashdbFavorites: 'STUDIO',
-          tagIds: ['tag-1'],
-          tagNames: ['Feature'],
-          tagMode: 'AND',
-          studioIds: ['studio-9'],
-          studioNames: ['Pulse'],
-          stashFavoritePerformersOnly: false,
-          stashFavoriteStudiosOnly: false,
-          stashFavoriteTagsOnly: false,
-          libraryAvailability: 'MISSING_FROM_LIBRARY',
           limit: 18,
         },
       }),
-    );
-
-    const result = await service.createRail({
-      source: 'HYBRID',
-      title: ' Missing Favorite Studios ',
-      subtitle: '',
-      enabled: true,
-      config: {
-        sort: 'DATE',
-        direction: 'DESC',
-        stashdbFavorites: 'STUDIO',
-        tagIds: ['tag-1'],
-        tagNames: ['Feature'],
-        tagMode: 'AND',
-        studioIds: ['studio-9'],
-        studioNames: ['Pulse'],
-        stashFavoritePerformersOnly: false,
-        stashFavoriteStudiosOnly: false,
-        stashFavoriteTagsOnly: false,
-        libraryAvailability: 'MISSING_FROM_LIBRARY',
-        limit: 18,
-      },
-    });
-
-    expect(createMock).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        source: 'HYBRID',
-        title: 'Missing Favorite Studios',
-        config: {
-          sort: 'DATE',
-          direction: 'DESC',
-          stashdbFavorites: 'STUDIO',
-          tagIds: ['tag-1'],
-          tagNames: ['Feature'],
-          tagMode: 'AND',
-          studioIds: ['studio-9'],
-          studioNames: ['Pulse'],
-          stashFavoritePerformersOnly: false,
-          stashFavoriteStudiosOnly: false,
-          stashFavoriteTagsOnly: false,
-          libraryAvailability: 'MISSING_FROM_LIBRARY',
-          limit: 18,
-        },
-      }),
-    });
-    expect(result).toMatchObject({
-      source: 'HYBRID',
-      config: {
-        stashdbFavorites: 'STUDIO',
-        libraryAvailability: 'MISSING_FROM_LIBRARY',
-      },
-    });
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   it('updates a custom rail config and metadata', async () => {
@@ -624,107 +579,31 @@ describe('HomeService', () => {
     });
   });
 
-  it('updates a custom hybrid rail with provider-scoped favorites and availability mode', async () => {
+  it('rejects editing legacy hybrid rails', async () => {
     upsertMock.mockResolvedValue({});
     findUniqueMock.mockResolvedValue(
       buildHybridRail({
         id: 'custom-hybrid-1',
-        config: {
-          sort: 'DATE',
-          direction: 'DESC',
-          stashdbFavorites: null,
-          tagIds: [],
-          tagNames: [],
-          tagMode: null,
-          studioIds: [],
-          studioNames: [],
-          stashFavoritePerformersOnly: false,
-          stashFavoriteStudiosOnly: false,
-          stashFavoriteTagsOnly: false,
-          libraryAvailability: 'MISSING_FROM_LIBRARY',
-          limit: 16,
-        },
       }),
     );
-    updateMock.mockResolvedValue(
-      buildHybridRail({
-        id: 'custom-hybrid-1',
+
+    await expect(
+      service.updateRail('custom-hybrid-1', {
+        source: 'STASHDB',
         title: 'Already in Library Favorites',
         subtitle: 'Updated subtitle',
         enabled: false,
         config: {
           sort: 'TITLE',
           direction: 'ASC',
-          stashdbFavorites: 'PERFORMER',
-          tagIds: ['tag-4'],
-          tagNames: ['Archive'],
-          tagMode: 'OR',
-          studioIds: ['studio-8'],
-          studioNames: ['North'],
-          stashFavoritePerformersOnly: true,
-          stashFavoriteStudiosOnly: false,
-          stashFavoriteTagsOnly: true,
-          libraryAvailability: 'IN_LIBRARY',
           limit: 12,
         },
       }),
-    );
-
-    const result = await service.updateRail('custom-hybrid-1', {
-      source: 'HYBRID',
-      title: 'Already in Library Favorites',
-      subtitle: 'Updated subtitle',
-      enabled: false,
-      config: {
-        sort: 'TITLE',
-        direction: 'ASC',
-        stashdbFavorites: 'PERFORMER',
-        tagIds: ['tag-4'],
-        tagNames: ['Archive'],
-        tagMode: 'OR',
-        studioIds: ['studio-8'],
-        studioNames: ['North'],
-        stashFavoritePerformersOnly: true,
-        stashFavoriteStudiosOnly: false,
-        stashFavoriteTagsOnly: true,
-        libraryAvailability: 'IN_LIBRARY',
-        limit: 12,
-      },
-    });
-
-    expect(updateMock).toHaveBeenCalledWith({
-      where: { id: 'custom-hybrid-1' },
-      data: expect.objectContaining({
-        title: 'Already in Library Favorites',
-        subtitle: 'Updated subtitle',
-        enabled: false,
-        config: {
-          sort: 'TITLE',
-          direction: 'ASC',
-          stashdbFavorites: 'PERFORMER',
-          tagIds: ['tag-4'],
-          tagNames: ['Archive'],
-          tagMode: 'OR',
-          studioIds: ['studio-8'],
-          studioNames: ['North'],
-          stashFavoritePerformersOnly: true,
-          stashFavoriteStudiosOnly: false,
-          stashFavoriteTagsOnly: true,
-          libraryAvailability: 'IN_LIBRARY',
-          limit: 12,
-        },
-      }),
-    });
-    expect(result).toMatchObject({
-      source: 'HYBRID',
-      config: {
-        stashdbFavorites: 'PERFORMER',
-        libraryAvailability: 'IN_LIBRARY',
-      },
-    });
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
-  it('rejects unsupported source-specific config pollution and source switching', async () => {
+  it('rejects unsupported source-specific config pollution, hybrid source attempts, and source switching', async () => {
     upsertMock.mockResolvedValue({});
 
     await expect(
@@ -742,23 +621,21 @@ describe('HomeService', () => {
       }),
     ).rejects.toBeInstanceOf(BadRequestException);
 
+    findUniqueMock.mockResolvedValue(buildRail({ id: 'custom-1' }));
+
     await expect(
-      service.createRail({
-        source: 'HYBRID',
+      service.updateRail('custom-1', {
+        source: 'HYBRID' as never,
         title: 'Bad Hybrid Rail',
         subtitle: null,
         enabled: true,
         config: {
           sort: 'DATE',
           direction: 'DESC',
-          favorites: 'ALL',
-          libraryAvailability: 'IN_LIBRARY',
           limit: 16,
         },
       }),
     ).rejects.toBeInstanceOf(BadRequestException);
-
-    findUniqueMock.mockResolvedValue(buildRail({ id: 'custom-1' }));
 
     await expect(
       service.updateRail('custom-1', {

--- a/apps/sp-api/src/home/home.service.spec.ts
+++ b/apps/sp-api/src/home/home.service.spec.ts
@@ -1015,6 +1015,23 @@ describe('HomeService', () => {
     expect(stashGetLocalSceneFeedMock).not.toHaveBeenCalled();
   });
 
+  it('does not serve disabled legacy hybrid rails by id', async () => {
+    upsertMock.mockResolvedValue({});
+    findUniqueMock.mockResolvedValue(
+      buildHybridRail({
+        id: 'custom-hybrid-disabled',
+        enabled: false,
+      }),
+    );
+
+    await expect(
+      service.getRailContent('custom-hybrid-disabled'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(stashdbGetScenesBySortMock).not.toHaveBeenCalled();
+    expect(stashFindScenesByStashIdMock).not.toHaveBeenCalled();
+    expect(sceneStatusResolveForScenesMock).not.toHaveBeenCalled();
+  });
+
   it('loads hybrid content by discovering on StashDB and matching in-library scenes in Stash', async () => {
     upsertMock.mockResolvedValue({});
     findUniqueMock.mockResolvedValue(

--- a/apps/sp-api/src/home/home.service.ts
+++ b/apps/sp-api/src/home/home.service.ts
@@ -30,19 +30,17 @@ import {
   HOME_RAIL_CONTENT_TYPE_VALUES,
   HOME_RAIL_DIRECTION_VALUES,
   HOME_RAIL_FAVORITES_VALUES,
-  HOME_RAIL_LIBRARY_AVAILABILITY_VALUES,
   HOME_RAIL_SCENE_LIMIT_DEFAULT,
   HOME_RAIL_SCENE_LIMIT_MAX,
   HOME_RAIL_SCENE_LIMIT_MIN,
   HOME_RAIL_SOURCE_VALUES,
-  type HomeRailLibraryAvailability,
-  type HomeRailHybridSceneConfigDto,
   HOME_RAIL_STASH_SCENE_SORT_VALUES,
   HOME_RAIL_STASHDB_SCENE_SORT_VALUES,
   HOME_RAIL_TAG_MODE_VALUES,
   HomeRailDto,
   type HomeRailKey as HomeRailDtoKey,
   type HomeRailSceneConfigDto,
+  type HomeRailSource as HomeRailDtoSource,
   type HomeRailStashSceneConfigDto,
   type HomeRailStashdbSceneConfigDto,
 } from './dto/home-rail.dto';
@@ -56,6 +54,15 @@ import {
   HomeRailItemDto,
 } from './dto/home-rail-content.dto';
 import { HybridScenesService } from '../hybrid-scenes/hybrid-scenes.service';
+import {
+  LEGACY_HOME_RAIL_LIBRARY_AVAILABILITY_VALUES,
+  type LegacyHomeRailHybridSceneConfig,
+  type LegacyHomeRailLibraryAvailability,
+} from './home-rail-hybrid.internal';
+
+type HomeRailStoredSceneConfig =
+  | HomeRailSceneConfigDto
+  | LegacyHomeRailHybridSceneConfig;
 
 const DEFAULT_HOME_RAILS: Array<{
   key: HomeRailKey;
@@ -146,13 +153,13 @@ export class HomeService {
   ) {}
 
   async getRails(): Promise<HomeRailDto[]> {
-    await this.ensureDefaultRails();
+    await this.ensureUserFacingRailsReady();
     const rails = await this.listRails();
     return rails.map((rail) => this.toDto(rail));
   }
 
   async updateRails(payload: UpdateHomeRailsDto): Promise<HomeRailDto[]> {
-    await this.ensureDefaultRails();
+    await this.ensureUserFacingRailsReady();
     const existingRails = await this.listRails();
     this.validateSubmittedRails(payload, existingRails);
 
@@ -172,7 +179,8 @@ export class HomeService {
   }
 
   async createRail(payload: CreateHomeRailDto): Promise<HomeRailDto> {
-    await this.ensureDefaultRails();
+    await this.ensureUserFacingRailsReady();
+    this.ensureSupportedCustomRailSource(payload.source);
     const lastRail = await this.prisma.homeRail.findFirst({
       orderBy: { sortOrder: 'desc' },
     });
@@ -201,8 +209,14 @@ export class HomeService {
     id: string,
     payload: UpdateHomeRailDto,
   ): Promise<HomeRailDto> {
-    await this.ensureDefaultRails();
+    await this.ensureUserFacingRailsReady();
+    this.ensureSupportedCustomRailSource(payload.source);
     const existingRail = await this.requireCustomRail(id);
+    if (existingRail.source === HomeRailSource.HYBRID) {
+      throw new BadRequestException(
+        'Legacy hybrid Home rails are disabled and cannot be edited.',
+      );
+    }
     if (payload.source !== existingRail.source) {
       throw new BadRequestException(
         'Custom Home rail source cannot be changed after creation.',
@@ -226,14 +240,14 @@ export class HomeService {
   }
 
   async deleteRail(id: string): Promise<void> {
-    await this.ensureDefaultRails();
+    await this.ensureUserFacingRailsReady();
     await this.requireCustomRail(id);
     await this.prisma.homeRail.delete({ where: { id } });
     await this.reindexSortOrders();
   }
 
   async getRailContent(id: string): Promise<HomeRailContentDto> {
-    await this.ensureDefaultRails();
+    await this.ensureUserFacingRailsReady();
     const rail = await this.prisma.homeRail.findUnique({ where: { id } });
     if (!rail) {
       throw new NotFoundException('Home rail not found.');
@@ -286,6 +300,11 @@ export class HomeService {
     }));
   }
 
+  private async ensureUserFacingRailsReady(): Promise<void> {
+    await this.ensureDefaultRails();
+    await this.disableLegacyHybridRails();
+  }
+
   private async ensureDefaultRails(): Promise<void> {
     for (const rail of DEFAULT_HOME_RAILS) {
       await this.prisma.homeRail.upsert({
@@ -313,15 +332,27 @@ export class HomeService {
     }
   }
 
+  private async disableLegacyHybridRails(): Promise<void> {
+    await this.prisma.homeRail.updateMany({
+      where: {
+        source: HomeRailSource.HYBRID,
+        enabled: true,
+      },
+      data: {
+        enabled: false,
+      },
+    });
+  }
+
   private async getStashRailContent(
     rail: HomeRail,
   ): Promise<HomeRailContentDto> {
     const config = this.normalizeSceneRailConfig(
-      rail.source,
+      'STASH',
       rail.config,
       DEFAULT_HOME_RAILS.find((defaultRail) => defaultRail.key === rail.key)
         ?.config ?? null,
-    ) as HomeRailStashSceneConfigDto;
+    );
 
     try {
       const items = await this.libraryService.getScenesPreview(
@@ -379,10 +410,10 @@ export class HomeService {
     }
 
     const config = this.normalizeSceneRailConfig(
-      rail.source,
+      'HYBRID',
       rail.config,
       null,
-    ) as HomeRailHybridSceneConfigDto;
+    );
 
     try {
       const matchedScenes = await this.hybridScenesService.getHybridSceneFeed(
@@ -433,6 +464,11 @@ export class HomeService {
 
   private async listRails(): Promise<HomeRail[]> {
     return this.prisma.homeRail.findMany({
+      where: {
+        source: {
+          not: HomeRailSource.HYBRID,
+        },
+      },
       orderBy: { sortOrder: 'asc' },
     });
   }
@@ -495,12 +531,13 @@ export class HomeService {
     const defaults = rail.key
       ? DEFAULT_HOME_RAILS.find((defaultRail) => defaultRail.key === rail.key)
       : null;
+    const source = this.ensureInSet(rail.source, HOME_RAIL_SOURCE_VALUES);
 
     return {
       id: rail.id,
       key: (rail.key as HomeRailDtoKey | null) ?? null,
       kind: rail.kind,
-      source: this.ensureInSet(rail.source, HOME_RAIL_SOURCE_VALUES),
+      source,
       contentType: this.ensureInSet(
         rail.contentType,
         HOME_RAIL_CONTENT_TYPE_VALUES,
@@ -512,7 +549,7 @@ export class HomeService {
       editable: rail.kind === HomeRailKind.CUSTOM,
       deletable: rail.kind === HomeRailKind.CUSTOM,
       config: this.normalizeSceneRailConfig(
-        rail.source,
+        source,
         rail.config,
         defaults?.config ?? null,
       ),
@@ -543,7 +580,7 @@ export class HomeService {
 
   private toHybridRailItem(
     scene: StashdbScene,
-    libraryAvailability: HomeRailLibraryAvailability,
+    libraryAvailability: LegacyHomeRailLibraryAvailability,
     status: SceneStatusDto,
   ): HomeRailItemDto {
     const effectiveStatus =
@@ -573,10 +610,30 @@ export class HomeService {
   }
 
   private normalizeSceneRailConfig(
+    source: 'STASH',
+    input: unknown,
+    fallback?: Partial<HomeRailStoredSceneConfig> | null,
+  ): HomeRailStashSceneConfigDto;
+  private normalizeSceneRailConfig(
+    source: 'STASHDB',
+    input: unknown,
+    fallback?: Partial<HomeRailStoredSceneConfig> | null,
+  ): HomeRailStashdbSceneConfigDto;
+  private normalizeSceneRailConfig(
+    source: HomeRailDtoSource,
+    input: unknown,
+    fallback?: Partial<HomeRailStoredSceneConfig> | null,
+  ): HomeRailSceneConfigDto;
+  private normalizeSceneRailConfig(
+    source: 'HYBRID',
+    input: unknown,
+    fallback?: Partial<HomeRailStoredSceneConfig> | null,
+  ): LegacyHomeRailHybridSceneConfig;
+  private normalizeSceneRailConfig(
     source: HomeRailSource,
     input: unknown,
-    fallback: Partial<HomeRailSceneConfigDto> | null = null,
-  ): HomeRailSceneConfigDto {
+    fallback: Partial<HomeRailStoredSceneConfig> | null = null,
+  ): HomeRailStoredSceneConfig {
     const record = this.asRecord(input);
     if (source === HomeRailSource.STASH) {
       return this.normalizeStashSceneRailConfig(record, fallback);
@@ -590,7 +647,7 @@ export class HomeService {
 
   private normalizeStashdbSceneRailConfig(
     record: Record<string, unknown>,
-    fallback: Partial<HomeRailSceneConfigDto> | null,
+    fallback: Partial<HomeRailStoredSceneConfig> | null,
   ): HomeRailStashdbSceneConfigDto {
     const fallbackConfig = this.asStashdbSceneConfig(fallback);
     const sort = this.parseInSet(
@@ -643,7 +700,7 @@ export class HomeService {
 
   private normalizeStashSceneRailConfig(
     record: Record<string, unknown>,
-    fallback: Partial<HomeRailSceneConfigDto> | null,
+    fallback: Partial<HomeRailStoredSceneConfig> | null,
   ): HomeRailStashSceneConfigDto {
     this.ensureNullishField(record.favorites, 'favorites', 'STASH');
     this.ensureNullishField(
@@ -740,8 +797,8 @@ export class HomeService {
 
   private normalizeHybridSceneRailConfig(
     record: Record<string, unknown>,
-    fallback: Partial<HomeRailSceneConfigDto> | null,
-  ): HomeRailHybridSceneConfigDto {
+    fallback: Partial<HomeRailStoredSceneConfig> | null,
+  ): LegacyHomeRailHybridSceneConfig {
     this.ensureNullishField(record.favorites, 'favorites', 'HYBRID');
     this.ensureNullishField(record.titleQuery, 'titleQuery', 'HYBRID');
     this.ensureFalseField(
@@ -797,7 +854,7 @@ export class HomeService {
         : null;
     const libraryAvailability = this.parseOptionalStrictInSet(
       record.libraryAvailability,
-      HOME_RAIL_LIBRARY_AVAILABILITY_VALUES,
+      LEGACY_HOME_RAIL_LIBRARY_AVAILABILITY_VALUES,
       fallbackConfig?.libraryAvailability ?? 'MISSING_FROM_LIBRARY',
       'libraryAvailability',
     );
@@ -928,7 +985,7 @@ export class HomeService {
   }
 
   private asStashdbSceneConfig(
-    value: Partial<HomeRailSceneConfigDto> | null,
+    value: Partial<HomeRailStoredSceneConfig> | null,
   ): Partial<HomeRailStashdbSceneConfigDto> | null {
     if (
       !value ||
@@ -943,7 +1000,7 @@ export class HomeService {
   }
 
   private asStashSceneConfig(
-    value: Partial<HomeRailSceneConfigDto> | null,
+    value: Partial<HomeRailStoredSceneConfig> | null,
   ): Partial<HomeRailStashSceneConfigDto> | null {
     if (!value) {
       return null;
@@ -986,14 +1043,14 @@ export class HomeService {
   }
 
   private asHybridSceneConfig(
-    value: Partial<HomeRailSceneConfigDto> | null,
-  ): Partial<HomeRailHybridSceneConfigDto> | null {
+    value: Partial<HomeRailStoredSceneConfig> | null,
+  ): Partial<LegacyHomeRailHybridSceneConfig> | null {
     if (!value) {
       return null;
     }
 
     if ('stashdbFavorites' in value || 'libraryAvailability' in value) {
-      return value as Partial<HomeRailHybridSceneConfigDto>;
+      return value as Partial<LegacyHomeRailHybridSceneConfig>;
     }
 
     return null;
@@ -1068,6 +1125,18 @@ export class HomeService {
     }
 
     return value as T[number];
+  }
+
+  private ensureSupportedCustomRailSource(source: unknown): void {
+    if (source === HomeRailSource.HYBRID) {
+      throw new BadRequestException(
+        'Custom HYBRID Home rails are no longer supported.',
+      );
+    }
+
+    if (source !== HomeRailSource.STASHDB && source !== HomeRailSource.STASH) {
+      throw new BadRequestException('Unsupported Home rail source.');
+    }
   }
 
   private normalizeSubtitle(value: string | null | undefined): string | null {

--- a/apps/sp-api/src/home/home.service.ts
+++ b/apps/sp-api/src/home/home.service.ts
@@ -253,6 +253,10 @@ export class HomeService {
       throw new NotFoundException('Home rail not found.');
     }
 
+    if (rail.source === HomeRailSource.HYBRID && !rail.enabled) {
+      throw new NotFoundException('Home rail not found.');
+    }
+
     if (rail.contentType !== HomeRailContentType.SCENES) {
       throw new BadRequestException('Unsupported Home rail content type.');
     }

--- a/apps/sp-web/src/app/core/api/home.types.ts
+++ b/apps/sp-web/src/app/core/api/home.types.ts
@@ -13,11 +13,10 @@ export type HomeRailKey =
   | 'FAVORITE_PERFORMERS'
   | 'RECENTLY_ADDED_LIBRARY';
 export type HomeRailKind = 'BUILTIN' | 'CUSTOM';
-export type HomeRailSource = 'STASHDB' | 'STASH' | 'HYBRID';
-export type HomeRailItemSource = HomeRailSource | CatalogProviderType;
+export type HomeRailSource = 'STASHDB' | 'STASH';
+export type HomeRailItemSource = 'STASH' | CatalogProviderType;
 export type HomeRailContentType = 'SCENES';
 export type HomeStashSceneSort = 'CREATED_AT' | 'UPDATED_AT' | 'TITLE';
-export type HomeHybridLibraryAvailability = 'IN_LIBRARY' | 'MISSING_FROM_LIBRARY';
 
 export interface HomeStashdbSceneRailConfig {
   sort: SceneFeedSort;
@@ -46,22 +45,6 @@ export interface HomeStashSceneRailConfig {
   limit: number;
 }
 
-export interface HomeHybridSceneRailConfig {
-  sort: SceneFeedSort;
-  direction: SortDirection;
-  stashdbFavorites: SceneFavoritesFilter | null;
-  tagIds: string[];
-  tagNames: string[];
-  tagMode: SceneTagMatchMode | null;
-  studioIds: string[];
-  studioNames: string[];
-  stashFavoritePerformersOnly: boolean;
-  stashFavoriteStudiosOnly: boolean;
-  stashFavoriteTagsOnly: boolean;
-  libraryAvailability: HomeHybridLibraryAvailability;
-  limit: number;
-}
-
 interface BaseHomeRailConfig<TSource extends HomeRailSource, TConfig> {
   id: string;
   key: HomeRailKey | null;
@@ -79,8 +62,7 @@ interface BaseHomeRailConfig<TSource extends HomeRailSource, TConfig> {
 
 export type HomeRailConfig =
   | BaseHomeRailConfig<'STASHDB', HomeStashdbSceneRailConfig>
-  | BaseHomeRailConfig<'STASH', HomeStashSceneRailConfig>
-  | BaseHomeRailConfig<'HYBRID', HomeHybridSceneRailConfig>;
+  | BaseHomeRailConfig<'STASH', HomeStashSceneRailConfig>;
 
 export interface HomeRailItem {
   id: string;
@@ -117,7 +99,7 @@ export interface SaveHomeRailPayload {
   title: string;
   subtitle: string | null;
   enabled: boolean;
-  config: HomeStashdbSceneRailConfig | HomeStashSceneRailConfig | HomeHybridSceneRailConfig;
+  config: HomeStashdbSceneRailConfig | HomeStashSceneRailConfig;
 }
 
 export interface HomeRailFormDraft {
@@ -129,15 +111,10 @@ export interface HomeRailFormDraft {
   direction: SortDirection;
   titleQuery: string;
   favorites: SceneFavoritesFilter | 'NONE';
-  stashdbFavorites: SceneFavoritesFilter | 'NONE';
   tagMode: SceneTagMatchMode;
   favoritePerformersOnly: boolean;
   favoriteStudiosOnly: boolean;
   favoriteTagsOnly: boolean;
-  stashFavoritePerformersOnly: boolean;
-  stashFavoriteStudiosOnly: boolean;
-  stashFavoriteTagsOnly: boolean;
-  libraryAvailability: HomeHybridLibraryAvailability;
   limit: number;
   selectedTags: SceneTagOption[];
   selectedStudios: Array<{
@@ -151,7 +128,6 @@ export interface HomeRailViewSummary {
   favoritesLabel: string;
   stashLocalFavoritesLabel: string | null;
   titleQueryLabel: string | null;
-  libraryAvailabilityLabel: string | null;
   tagCount: number;
   studioCount: number;
   limit: number;

--- a/apps/sp-web/src/app/pages/home/home-page.component.html
+++ b/apps/sp-web/src/app/pages/home/home-page.component.html
@@ -55,7 +55,7 @@
         <div class="editor-head">
           <div>
             <p class="eyebrow">Customize Home</p>
-            <h2>Reorder built-ins and add custom Catalog, Stash, or Hybrid scene rails</h2>
+            <h2>Reorder built-ins and add custom Catalog or Stash scene rails</h2>
           </div>
           <div class="editor-actions">
             <button type="button" class="state-button secondary" (click)="cancelEditor()">
@@ -123,13 +123,6 @@
                   }
                   @if (railLocalFavoritesValue(rail); as localFavorites) {
                     <span>{{ localFavorites }}</span>
-                  }
-                  @if (isHybridRail(rail)) {
-                    <span>{{
-                      rail.config.libraryAvailability === 'IN_LIBRARY'
-                        ? 'Already In Library'
-                        : 'Missing From Library'
-                    }}</span>
                   }
                   @if (railTagCount(rail) > 0) {
                     <span>{{ railTagCount(rail) }} tags</span>
@@ -246,7 +239,7 @@
               @if (editingRailId()) {
                 <p class="editor-note source-note">
                   Source is fixed after creation. Create a new rail if you want to switch between
-                  Catalog, Stash, and Hybrid.
+                  Catalog and Stash.
                 </p>
               }
 
@@ -259,9 +252,7 @@
                   [placeholder]="
                     form.source === 'STASH'
                       ? 'Newest Library Scenes, Recently Updated Library...'
-                      : form.source === 'HYBRID'
-                        ? 'Missing from library, In-library favorites...'
-                        : 'Weekend queue, New tags, Favorite studios...'
+                      : 'Weekend queue, New tags, Favorite studios...'
                   "
                 />
               </label>
@@ -356,48 +347,6 @@
                     panelStyleClass="home-rail-select-panel"
                   />
                 </label>
-              } @else if (form.source === 'HYBRID') {
-                <label class="control-field">
-                  <span>Catalog Favorites</span>
-                  <p-select
-                    inputId="home-rail-hybrid-favorites"
-                    [ngModel]="form.stashdbFavorites"
-                    (ngModelChange)="updateRailForm('stashdbFavorites', $event)"
-                    [options]="favoritesOptions"
-                    optionLabel="label"
-                    optionValue="value"
-                    [appendTo]="'body'"
-                    panelStyleClass="home-rail-select-panel"
-                  />
-                </label>
-
-                <label class="control-field">
-                  <span>Library Availability</span>
-                  <p-select
-                    inputId="home-rail-library-availability"
-                    [ngModel]="form.libraryAvailability"
-                    (ngModelChange)="updateRailForm('libraryAvailability', $event)"
-                    [options]="hybridLibraryAvailabilityOptions"
-                    optionLabel="label"
-                    optionValue="value"
-                    [appendTo]="'body'"
-                    panelStyleClass="home-rail-select-panel"
-                  />
-                </label>
-
-                <label class="control-field">
-                  <span>Tag Mode</span>
-                  <p-select
-                    inputId="home-rail-hybrid-tag-mode"
-                    [ngModel]="form.tagMode"
-                    (ngModelChange)="updateRailForm('tagMode', $event)"
-                    [options]="tagMatchOptions"
-                    optionLabel="label"
-                    optionValue="value"
-                    [appendTo]="'body'"
-                    panelStyleClass="home-rail-select-panel"
-                  />
-                </label>
               } @else {
                 <label class="control-field">
                   <span>Title Contains</span>
@@ -425,7 +374,7 @@
               }
             </div>
 
-            @if (form.source === 'STASHDB' || form.source === 'STASH' || form.source === 'HYBRID') {
+            @if (form.source === 'STASHDB' || form.source === 'STASH') {
               <div class="rail-form-pickers">
                 <label class="control-field">
                   <span>Tags</span>
@@ -535,54 +484,8 @@
                 </div>
 
                 <p class="editor-note source-note">
-                  Stash rails use your local library filters only. This slice supports title search,
-                  local tags, local studios, and favorite performer, studio, or tag toggles.
-                </p>
-              } @else if (form.source === 'HYBRID') {
-                <p class="editor-note source-note source-subsection">Stash Local Favorites</p>
-                <div class="rail-form-grid stash-toggle-grid">
-                  <label class="control-field checkbox-field compact-toggle">
-                    <span>Only Favorite Performers</span>
-                    <label class="toggle-inline">
-                      <input
-                        type="checkbox"
-                        [ngModel]="form.stashFavoritePerformersOnly"
-                        (ngModelChange)="updateRailForm('stashFavoritePerformersOnly', $event)"
-                      />
-                      <span>{{ form.stashFavoritePerformersOnly ? 'Enabled' : 'Disabled' }}</span>
-                    </label>
-                  </label>
-
-                  <label class="control-field checkbox-field compact-toggle">
-                    <span>Only Favorite Studios</span>
-                    <label class="toggle-inline">
-                      <input
-                        type="checkbox"
-                        [ngModel]="form.stashFavoriteStudiosOnly"
-                        (ngModelChange)="updateRailForm('stashFavoriteStudiosOnly', $event)"
-                      />
-                      <span>{{ form.stashFavoriteStudiosOnly ? 'Enabled' : 'Disabled' }}</span>
-                    </label>
-                  </label>
-
-                  <label class="control-field checkbox-field compact-toggle">
-                    <span>Only Favorite Tags</span>
-                    <label class="toggle-inline">
-                      <input
-                        type="checkbox"
-                        [ngModel]="form.stashFavoriteTagsOnly"
-                        (ngModelChange)="updateRailForm('stashFavoriteTagsOnly', $event)"
-                      />
-                      <span>{{ form.stashFavoriteTagsOnly ? 'Enabled' : 'Disabled' }}</span>
-                    </label>
-                  </label>
-                </div>
-
-                <p class="editor-note source-note">
-                  Hybrid rails discover scenes from the catalog provider configured for this
-                  instance, then filter them by whether they exist in your local Stash library.
-                  Catalog favorites drive discovery; Stash local favorites are applied as a
-                  separate overlay after library matching.
+                  Stash rails use your local library filters only, including title search, local
+                  tags, local studios, and favorite performer, studio, or tag toggles.
                 </p>
               }
             }
@@ -635,9 +538,6 @@
                     }
                     @if (rail.summary.titleQueryLabel) {
                       <span>{{ rail.summary.titleQueryLabel }}</span>
-                    }
-                    @if (rail.summary.libraryAvailabilityLabel) {
-                      <span>{{ rail.summary.libraryAvailabilityLabel }}</span>
                     }
                     <span>{{ rail.summary.limit }} items</span>
                     @if (rail.summary.tagCount > 0) {

--- a/apps/sp-web/src/app/pages/home/home-page.component.spec.ts
+++ b/apps/sp-web/src/app/pages/home/home-page.component.spec.ts
@@ -119,43 +119,11 @@ describe('HomePageComponent', () => {
           limit: 16,
         },
       },
-      {
-        id: 'rail-hybrid',
-        key: null,
-        kind: 'CUSTOM',
-        source: 'HYBRID',
-        contentType: 'SCENES',
-        title: 'Hybrid Rail',
-        subtitle: 'Curated hybrid results',
-        enabled: true,
-        sortOrder: 2,
-        editable: true,
-        deletable: true,
-        config: {
-          sort: 'DATE',
-          direction: 'DESC',
-          stashdbFavorites: null,
-          tagIds: [],
-          tagNames: [],
-          tagMode: null,
-          studioIds: [],
-          studioNames: [],
-          stashFavoritePerformersOnly: false,
-          stashFavoriteStudiosOnly: false,
-          stashFavoriteTagsOnly: false,
-          libraryAvailability: 'MISSING_FROM_LIBRARY',
-          limit: 16,
-        },
-      },
     ];
 
     const homeRailItemsById: Record<string, HomeRailContentResponse> = {
       'rail-stash': {
         items: [buildRailItem()],
-        message: null,
-      },
-      'rail-hybrid': {
-        items: [buildRailItem({ id: 'stashdb-scene-2', source: 'STASHDB', viewUrl: null })],
         message: null,
       },
     };
@@ -225,7 +193,7 @@ describe('HomePageComponent', () => {
     return section as HTMLElement;
   }
 
-  it('routes STASHDB rails to /scenes, STASH rails to /library, and leaves HYBRID rails without see-all links', async () => {
+  it('routes STASHDB rails to /scenes and STASH rails to /library', async () => {
     const { fixture, discoverService } = await renderPage();
 
     expect(discoverService.getScenesFeed).toHaveBeenCalledWith(
@@ -245,9 +213,6 @@ describe('HomePageComponent', () => {
     const libraryLink = railSectionByTitle(fixture, 'Library Rail').querySelector(
       '.see-all-link',
     ) as HTMLAnchorElement | null;
-    const hybridLink = railSectionByTitle(fixture, 'Hybrid Rail').querySelector(
-      '.see-all-link',
-    ) as HTMLAnchorElement | null;
 
     expect(discoveryLink?.getAttribute('href')).toContain('/scenes');
     expect(discoveryLink?.getAttribute('href')).toContain('fav=ALL');
@@ -263,8 +228,6 @@ describe('HomePageComponent', () => {
     expect(libraryLink?.getAttribute('href')).toContain('favoriteTagsOnly=1');
     expect(libraryLink?.getAttribute('href')).toContain('tags=tag-2');
     expect(libraryLink?.getAttribute('href')).toContain('studios=studio-2');
-
-    expect(hybridLink).toBeNull();
   });
 
   it('renders Home rails through the shared scene card and preserves request routing', async () => {
@@ -276,7 +239,7 @@ describe('HomePageComponent', () => {
     const requestButton = discoverySection.querySelector('.request-cta') as HTMLButtonElement | null;
     const libraryLink = librarySection.querySelector('.media-link-stretch') as HTMLAnchorElement | null;
 
-    expect(cards).toHaveLength(3);
+    expect(cards).toHaveLength(2);
     expect(libraryLink?.getAttribute('href')).toBe('http://stash.local/scenes/local-scene-1');
     expect(component.requestModalOpen()).toBe(false);
 
@@ -288,5 +251,30 @@ describe('HomePageComponent', () => {
       title: 'Discovery Scene',
       imageUrl: 'http://cdn.local/discovery.jpg',
     });
+  });
+
+  it('limits custom rail creation to Catalog and Stash and removes hybrid-only controls', async () => {
+    const { fixture } = await renderPage();
+    const component = fixture.componentInstance as any;
+
+    component.openEditor();
+    component.openCreateRailForm();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.sourceOptions.map((option: { value: string }) => option.value)).toEqual([
+      'STASHDB',
+      'STASH',
+    ]);
+    expect(fixture.nativeElement.textContent).not.toContain('Hybrid');
+    expect(fixture.nativeElement.querySelector('#home-rail-hybrid-favorites')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#home-rail-library-availability')).toBeNull();
+
+    component.updateRailSource('STASH');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('#home-rail-hybrid-favorites')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#home-rail-library-availability')).toBeNull();
   });
 });

--- a/apps/sp-web/src/app/pages/home/home-page.component.ts
+++ b/apps/sp-web/src/app/pages/home/home-page.component.ts
@@ -41,8 +41,6 @@ import {
   HomeRailContentResponse,
   HomeRailConfig,
   HomeRailFormDraft,
-  HomeHybridLibraryAvailability,
-  HomeHybridSceneRailConfig,
   HomeRailItem,
   HomeRailSource,
   HomeStashSceneSort,
@@ -109,8 +107,6 @@ export class HomePageComponent implements OnInit, OnDestroy {
   private static readonly DEFAULT_SORT: SceneFeedSort = 'DATE';
   private static readonly DEFAULT_DIRECTION: SortDirection = 'DESC';
   private static readonly DEFAULT_TAG_MODE: SceneTagMatchMode = 'OR';
-  private static readonly DEFAULT_LIBRARY_AVAILABILITY: HomeHybridLibraryAvailability =
-    'MISSING_FROM_LIBRARY';
 
   protected static readonly SORT_OPTIONS: Array<{ value: SceneFeedSort; label: string }> = [
     { value: 'DATE', label: 'Release Date' },
@@ -130,7 +126,6 @@ export class HomePageComponent implements OnInit, OnDestroy {
   protected static readonly SOURCE_OPTIONS: Array<{ value: HomeRailSource; label: string }> = [
     { value: 'STASHDB', label: 'Catalog' },
     { value: 'STASH', label: 'Stash' },
-    { value: 'HYBRID', label: 'Hybrid' },
   ];
   protected static readonly DIRECTION_OPTIONS: Array<{
     value: SortDirection;
@@ -154,13 +149,6 @@ export class HomePageComponent implements OnInit, OnDestroy {
   }> = [
     { value: 'OR', label: 'OR (Any)' },
     { value: 'AND', label: 'AND (All)' },
-  ];
-  protected static readonly HYBRID_LIBRARY_AVAILABILITY_OPTIONS: Array<{
-    value: HomeHybridLibraryAvailability;
-    label: string;
-  }> = [
-    { value: 'MISSING_FROM_LIBRARY', label: 'Missing From Library' },
-    { value: 'IN_LIBRARY', label: 'Already In Library' },
   ];
 
   private readonly discoverService = inject(DiscoverService);
@@ -219,8 +207,6 @@ export class HomePageComponent implements OnInit, OnDestroy {
   protected readonly sourceOptions = HomePageComponent.SOURCE_OPTIONS;
   protected readonly favoritesOptions = HomePageComponent.FAVORITES_OPTIONS;
   protected readonly tagMatchOptions = HomePageComponent.TAG_MATCH_OPTIONS;
-  protected readonly hybridLibraryAvailabilityOptions =
-    HomePageComponent.HYBRID_LIBRARY_AVAILABILITY_OPTIONS;
 
   ngOnInit(): void {
     this.setupTagSearch();
@@ -560,36 +546,16 @@ export class HomePageComponent implements OnInit, OnDestroy {
       | 'direction'
       | 'titleQuery'
       | 'favorites'
-      | 'stashdbFavorites'
       | 'tagMode'
       | 'favoritePerformersOnly'
       | 'favoriteStudiosOnly'
       | 'favoriteTagsOnly'
-      | 'stashFavoritePerformersOnly'
-      | 'stashFavoriteStudiosOnly'
-      | 'stashFavoriteTagsOnly'
-      | 'libraryAvailability'
       | 'limit'
     >,
   >(field: K, value: HomeRailFormDraft[K]): void {
-    this.railForm.update((current) => {
-      if (!current) {
-        return current;
-      }
-
-      const next = { ...current, [field]: value };
-      if (
-        field === 'libraryAvailability' &&
-        value === 'MISSING_FROM_LIBRARY' &&
-        next.source === 'HYBRID'
-      ) {
-        next.stashFavoritePerformersOnly = false;
-        next.stashFavoriteStudiosOnly = false;
-        next.stashFavoriteTagsOnly = false;
-      }
-
-      return next;
-    });
+    this.railForm.update((current) =>
+      current ? { ...current, [field]: value } : current,
+    );
   }
 
   protected updateRailSource(nextSource: HomeRailSource): void {
@@ -609,45 +575,12 @@ export class HomePageComponent implements OnInit, OnDestroy {
           sort: 'CREATED_AT',
           titleQuery: '',
           favorites: 'NONE',
-          stashdbFavorites: 'NONE',
           tagMode: HomePageComponent.DEFAULT_TAG_MODE,
           favoritePerformersOnly: false,
           favoriteStudiosOnly: false,
-          favoriteTagsOnly: current.source === 'HYBRID' ? current.stashFavoriteTagsOnly : false,
-          stashFavoritePerformersOnly:
-            current.source === 'HYBRID' ? current.stashFavoritePerformersOnly : false,
-          stashFavoriteStudiosOnly:
-            current.source === 'HYBRID' ? current.stashFavoriteStudiosOnly : false,
-          stashFavoriteTagsOnly: false,
-          libraryAvailability: HomePageComponent.DEFAULT_LIBRARY_AVAILABILITY,
+          favoriteTagsOnly: false,
           selectedTags: [],
           selectedStudios: [],
-        };
-      }
-
-      if (nextSource === 'HYBRID') {
-        return {
-          ...current,
-          source: 'HYBRID',
-          sort: 'DATE',
-          titleQuery: '',
-          favorites: 'NONE',
-          stashdbFavorites:
-            current.source === 'STASHDB'
-              ? current.favorites
-              : current.source === 'HYBRID'
-                ? current.stashdbFavorites
-                : 'NONE',
-          tagMode: current.tagMode,
-          favoritePerformersOnly: false,
-          favoriteStudiosOnly: false,
-          favoriteTagsOnly: false,
-          stashFavoritePerformersOnly: false,
-          stashFavoriteStudiosOnly: false,
-          stashFavoriteTagsOnly: false,
-          libraryAvailability: HomePageComponent.DEFAULT_LIBRARY_AVAILABILITY,
-          selectedTags: current.source === 'STASH' ? [] : current.selectedTags,
-          selectedStudios: current.source === 'STASH' ? [] : current.selectedStudios,
         };
       }
 
@@ -656,17 +589,12 @@ export class HomePageComponent implements OnInit, OnDestroy {
         source: 'STASHDB',
         sort: 'DATE',
         titleQuery: '',
-        favorites: current.source === 'HYBRID' ? current.stashdbFavorites : current.favorites,
-        stashdbFavorites: 'NONE',
+        favorites: current.favorites,
         favoritePerformersOnly: false,
         favoriteStudiosOnly: false,
         favoriteTagsOnly: false,
-        stashFavoritePerformersOnly: false,
-        stashFavoriteStudiosOnly: false,
-        stashFavoriteTagsOnly: false,
-        libraryAvailability: HomePageComponent.DEFAULT_LIBRARY_AVAILABILITY,
-        selectedTags: current.source === 'STASH' ? [] : current.selectedTags,
-        selectedStudios: current.source === 'STASH' ? [] : current.selectedStudios,
+        selectedTags: [],
+        selectedStudios: [],
       };
     });
     const updatedForm = this.railForm();
@@ -822,14 +750,7 @@ export class HomePageComponent implements OnInit, OnDestroy {
   }
 
   protected sourceLabel(source: HomeRailSource): string {
-    if (source === 'STASH') {
-      return 'Stash';
-    }
-    if (source === 'HYBRID') {
-      return 'Hybrid';
-    }
-
-    return 'Catalog';
+    return source === 'STASH' ? 'Stash' : 'Catalog';
   }
 
   protected isStashRail(
@@ -838,23 +759,8 @@ export class HomePageComponent implements OnInit, OnDestroy {
     return rail.source === 'STASH';
   }
 
-  protected isHybridRail(
-    rail: HomeRailConfig,
-  ): rail is Extract<HomeRailConfig, { source: 'HYBRID' }> {
-    return rail.source === 'HYBRID';
-  }
-
   protected isStashForm(): boolean {
     return this.railForm()?.source === 'STASH';
-  }
-
-  protected isHybridForm(): boolean {
-    return this.railForm()?.source === 'HYBRID';
-  }
-
-  protected showHybridLocalFavoritesControls(): boolean {
-    const form = this.railForm();
-    return form?.source === 'HYBRID' && form.libraryAvailability === 'IN_LIBRARY';
   }
 
   protected railFormSortOptions() {
@@ -862,20 +768,7 @@ export class HomePageComponent implements OnInit, OnDestroy {
   }
 
   protected railFavoritesValue(rail: HomeRailConfig): string | null {
-    const config = rail.config;
-
-    if (this.isStashdbConfig(config)) {
-      return (
-        HomePageComponent.FAVORITES_OPTIONS.find(
-          (option) => option.value === (config.favorites ?? 'NONE'),
-        )?.label ?? 'No Favorites Filter'
-      );
-    }
-    if (this.isHybridConfig(config)) {
-      return this.hybridFavoritesSummary(config);
-    }
-
-    return this.stashFavoriteSummary(config);
+    return this.favoritesLabelForRail(rail);
   }
 
   protected railLocalFavoritesValue(rail: HomeRailConfig): string | null {
@@ -941,7 +834,7 @@ export class HomePageComponent implements OnInit, OnDestroy {
   }
 
   private loadSingleRail(rail: HomeRailConfig) {
-    if (rail.source === 'STASH' || rail.source === 'HYBRID') {
+    if (rail.source === 'STASH') {
       return this.homeService.getRailItems(rail.id).pipe(
         map(
           (response: HomeRailContentResponse): RailLoadResult => ({
@@ -1061,7 +954,6 @@ export class HomePageComponent implements OnInit, OnDestroy {
       favoritesLabel: this.favoritesLabelForRail(rail),
       stashLocalFavoritesLabel: this.stashLocalFavoritesLabelForRail(rail),
       titleQueryLabel: this.titleQueryLabelForRail(rail),
-      libraryAvailabilityLabel: this.libraryAvailabilityLabelForRail(rail),
       tagCount: rail.config.tagIds.length,
       studioCount: rail.config.studioIds.length,
       limit: rail.config.limit,
@@ -1076,17 +968,6 @@ export class HomePageComponent implements OnInit, OnDestroy {
     return rails.map((rail): HomeRailConfig => {
       switch (rail.source) {
         case 'STASHDB':
-          return {
-            ...rail,
-            config: {
-              ...rail.config,
-              tagIds: [...rail.config.tagIds],
-              tagNames: [...rail.config.tagNames],
-              studioIds: [...rail.config.studioIds],
-              studioNames: [...rail.config.studioNames],
-            },
-          };
-        case 'HYBRID':
           return {
             ...rail,
             config: {
@@ -1123,21 +1004,10 @@ export class HomePageComponent implements OnInit, OnDestroy {
       direction: config.direction,
       titleQuery: this.isStashConfig(config) ? (config.titleQuery ?? '') : '',
       favorites: this.isStashdbConfig(config) ? (config.favorites ?? 'NONE') : 'NONE',
-      stashdbFavorites: this.isHybridConfig(config) ? (config.stashdbFavorites ?? 'NONE') : 'NONE',
       tagMode: config.tagMode ?? HomePageComponent.DEFAULT_TAG_MODE,
       favoritePerformersOnly: this.isStashConfig(config) ? config.favoritePerformersOnly : false,
       favoriteStudiosOnly: this.isStashConfig(config) ? config.favoriteStudiosOnly : false,
       favoriteTagsOnly: this.isStashConfig(config) ? config.favoriteTagsOnly : false,
-      stashFavoritePerformersOnly: this.isHybridConfig(config)
-        ? config.stashFavoritePerformersOnly
-        : false,
-      stashFavoriteStudiosOnly: this.isHybridConfig(config)
-        ? config.stashFavoriteStudiosOnly
-        : false,
-      stashFavoriteTagsOnly: this.isHybridConfig(config) ? config.stashFavoriteTagsOnly : false,
-      libraryAvailability: this.isHybridConfig(config)
-        ? config.libraryAvailability
-        : HomePageComponent.DEFAULT_LIBRARY_AVAILABILITY,
       limit: config.limit,
       selectedTags: config.tagIds
         ? config.tagIds.map((id, index) => ({
@@ -1166,15 +1036,10 @@ export class HomePageComponent implements OnInit, OnDestroy {
       direction: HomePageComponent.DEFAULT_DIRECTION,
       titleQuery: '',
       favorites: 'NONE',
-      stashdbFavorites: 'NONE',
       tagMode: HomePageComponent.DEFAULT_TAG_MODE,
       favoritePerformersOnly: false,
       favoriteStudiosOnly: false,
       favoriteTagsOnly: false,
-      stashFavoritePerformersOnly: false,
-      stashFavoriteStudiosOnly: false,
-      stashFavoriteTagsOnly: false,
-      libraryAvailability: HomePageComponent.DEFAULT_LIBRARY_AVAILABILITY,
       limit: HomePageComponent.DEFAULT_LIMIT,
       selectedTags: [],
       selectedStudios: [],
@@ -1200,43 +1065,6 @@ export class HomePageComponent implements OnInit, OnDestroy {
           favoritePerformersOnly: form.favoritePerformersOnly,
           favoriteStudiosOnly: form.favoriteStudiosOnly,
           favoriteTagsOnly: form.favoriteTagsOnly,
-          limit: Math.min(
-            Math.max(
-              Math.round(Number(form.limit) || HomePageComponent.DEFAULT_LIMIT),
-              HomePageComponent.LIMIT_MIN,
-            ),
-            HomePageComponent.LIMIT_MAX,
-          ),
-        },
-      };
-    }
-
-    if (form.source === 'HYBRID') {
-      const usesStashLocalFavoriteOverlays = form.libraryAvailability === 'IN_LIBRARY';
-      return {
-        source: 'HYBRID',
-        title: form.title.trim(),
-        subtitle: form.subtitle.trim() || null,
-        enabled: form.enabled,
-        config: {
-          sort: form.sort as SceneFeedSort,
-          direction: form.direction,
-          stashdbFavorites: form.stashdbFavorites === 'NONE' ? null : form.stashdbFavorites,
-          tagIds: form.selectedTags.map((tag) => tag.id),
-          tagNames: form.selectedTags.map((tag) => tag.name),
-          tagMode: form.selectedTags.length > 0 ? form.tagMode : null,
-          studioIds: form.selectedStudios.map((studio) => studio.id),
-          studioNames: form.selectedStudios.map((studio) => studio.label),
-          stashFavoritePerformersOnly: usesStashLocalFavoriteOverlays
-            ? form.stashFavoritePerformersOnly
-            : false,
-          stashFavoriteStudiosOnly: usesStashLocalFavoriteOverlays
-            ? form.stashFavoriteStudiosOnly
-            : false,
-          stashFavoriteTagsOnly: usesStashLocalFavoriteOverlays
-            ? form.stashFavoriteTagsOnly
-            : false,
-          libraryAvailability: form.libraryAvailability,
           limit: Math.min(
             Math.max(
               Math.round(Number(form.limit) || HomePageComponent.DEFAULT_LIMIT),
@@ -1434,19 +1262,12 @@ export class HomePageComponent implements OnInit, OnDestroy {
     return 'favorites' in config;
   }
 
-  private isHybridConfig(config: HomeRailConfig['config']): config is HomeHybridSceneRailConfig {
-    return 'libraryAvailability' in config;
-  }
-
   private isStashConfig(config: HomeRailConfig['config']): config is HomeStashSceneRailConfig {
-    return !this.isStashdbConfig(config) && !this.isHybridConfig(config);
+    return !this.isStashdbConfig(config);
   }
 
   private favoritesLabelForRail(rail: HomeRailConfig): string {
     const config = rail.config;
-    if (this.isHybridConfig(config)) {
-      return this.hybridFavoritesSummary(config);
-    }
     if (this.isStashConfig(config)) {
       return 'Local Library';
     }
@@ -1471,49 +1292,12 @@ export class HomePageComponent implements OnInit, OnDestroy {
     return null;
   }
 
-  private libraryAvailabilityLabelForRail(rail: HomeRailConfig): string | null {
-    if (!this.isHybridConfig(rail.config)) {
-      return null;
-    }
-
-    return rail.config.libraryAvailability === 'IN_LIBRARY'
-      ? 'Already In Library'
-      : 'Missing From Library';
-  }
-
-  private stashFavoriteSummary(config: HomeStashSceneRailConfig): string {
-    return (
-      this.stashLocalFavoritesSummary(
-        config.favoritePerformersOnly,
-        config.favoriteStudiosOnly,
-        config.favoriteTagsOnly,
-      ) ?? 'Local Library'
-    );
-  }
-
-  private hybridFavoritesSummary(config: HomeHybridSceneRailConfig): string {
-    const label =
-      HomePageComponent.FAVORITES_OPTIONS.find(
-        (option) => option.value === (config.stashdbFavorites ?? 'NONE'),
-      )?.label ?? 'No Favorites Filter';
-
-    return `Catalog ${label}`;
-  }
-
   private stashLocalFavoritesLabelForRail(rail: HomeRailConfig): string | null {
     if (this.isStashConfig(rail.config)) {
       return this.stashLocalFavoritesSummary(
         rail.config.favoritePerformersOnly,
         rail.config.favoriteStudiosOnly,
         rail.config.favoriteTagsOnly,
-      );
-    }
-
-    if (this.isHybridConfig(rail.config)) {
-      return this.stashLocalFavoritesSummary(
-        rail.config.stashFavoritePerformersOnly,
-        rail.config.stashFavoriteStudiosOnly,
-        rail.config.stashFavoriteTagsOnly,
       );
     }
 

--- a/prisma/migrations/20260406120000_disable_legacy_home_hybrid_rails/migration.sql
+++ b/prisma/migrations/20260406120000_disable_legacy_home_hybrid_rails/migration.sql
@@ -1,0 +1,4 @@
+UPDATE "HomeRail"
+SET "enabled" = false
+WHERE "source" = 'HYBRID'
+  AND "enabled" = true;


### PR DESCRIPTION
- limit custom Home rail sources to STASHDB and STASH in the UI and public API

- disable legacy hybrid rails and hide them from the user-facing Home model

- keep hybrid internals only for legacy service handling while removing hybrid DTO contract surface