### PR TITLE
feat(sp-web): align library page with scenes browse layout

### DIFF
--- a/apps/sp-web/src/app/pages/library/library-page.component.html
+++ b/apps/sp-web/src/app/pages/library/library-page.component.html
@@ -1,320 +1,223 @@
 <main>
-  <header class="page-head">
-    <div class="page-copy">
-      <p class="eyebrow">Local Collection</p>
-      <h1>Library</h1>
-      <p>Browse scenes already indexed from your local Stash library.</p>
-    </div>
-
-    <div class="page-head-actions">
-      <a class="secondary-link small" [routerLink]="['/scenes']">Browse Scenes</a>
-      <a class="secondary-link small" [routerLink]="['/acquisition']">Track Imports</a>
-    </div>
+  <header>
+    <h1>Library</h1>
+    <p>Browse scenes already indexed from your local Stash library.</p>
+    @if (!loading() && !error()) {
+      <p class="state">{{ libraryStateLabel() }}</p>
+    }
   </header>
-
-  <section class="summary-shell" aria-label="Library summary">
-    <article class="summary-card" [attr.title]="indexedSummaryTooltip()">
-      <span class="summary-card-label">Indexed Locally</span>
-      <strong class="summary-card-value">{{ totalSummaryValue() }}</strong>
-    </article>
-
-    <article class="summary-card" [attr.title]="viewSummaryTooltip()">
-      <span class="summary-card-label">Current View</span>
-      <strong class="summary-card-value">{{ viewSummaryValue() }}</strong>
-      <span class="summary-card-meta">{{ viewSummaryMeta() }}</span>
-    </article>
-
-    <article class="summary-card">
-      <div class="summary-card-head">
-        <span class="summary-card-label">Projection Freshness</span>
-        <span
-          class="info-hint pi pi-info-circle"
-          [attr.title]="freshnessSummaryTooltip()"
-          aria-hidden="true"
-        ></span>
-      </div>
-      <strong class="summary-card-value">{{ freshnessSummaryValue() }}</strong>
-    </article>
-  </section>
 
   @if (pageAlert(); as alert) {
     <section class="page-alert" data-testid="library-degraded-state" role="status">
       <div class="page-alert-copy">
-        <p class="eyebrow">{{ alert.eyebrow }}</p>
-        <h2>{{ alert.title }}</h2>
+        <p class="page-alert-title">{{ alert.title }}</p>
         <p>{{ alert.message }}</p>
       </div>
 
       <div class="page-alert-actions">
-        <a class="primary-link small" [routerLink]="['/settings']">Open Settings</a>
+        <a class="secondary-link small" [routerLink]="['/settings']">Open Settings</a>
         <a class="secondary-link small" [routerLink]="['/acquisition']">Track Imports</a>
       </div>
     </section>
   }
 
   <section class="controls-shell" aria-label="Library controls">
-    <div class="controls-overview">
-      <div>
-        <p class="eyebrow">Local Filters</p>
-        <h2>Refine the library</h2>
+    <div class="controls-header">
+      <span class="controls-title">Local Library</span>
+      <div class="controls-actions">
+        <button
+          type="button"
+          class="reset-filters-button"
+          [disabled]="!hasActiveFilters()"
+          title="Clear filters and return to the default local library view"
+          (click)="resetFilters()"
+        >
+          Clear Filters
+        </button>
       </div>
-
-      <button
-        type="button"
-        class="secondary-action"
-        [disabled]="!hasActiveFilters()"
-        title="Clear filters and return to the default library view"
-        (click)="resetFilters()"
-      >
-        Clear Filters
-      </button>
     </div>
 
-    <div class="controls-grid">
-      <article class="control-card search-card">
-        <label class="control-field search-field">
-          <span>Text Query</span>
-          <input
-            type="search"
-            inputmode="search"
-            [ngModel]="queryTerm()"
-            (ngModelChange)="onQueryChanged($event)"
-            placeholder="Search titles, descriptions, or studios"
-          />
-        </label>
-      </article>
+    <div class="controls-row">
+      <label class="control-field control-field--query">
+        <span>Text Query</span>
+        <input
+          type="search"
+          inputmode="search"
+          [ngModel]="queryTerm()"
+          (ngModelChange)="onQueryChanged($event)"
+          placeholder="Search titles, descriptions, or studios"
+        />
+      </label>
 
-      <article class="control-card">
-        <label class="control-field">
-          <span>Studio Filter</span>
+      <label class="control-field control-field--studio">
+        <span>Studio Filter</span>
+        <p-multiselect
+          inputId="library-studios"
+          [ngModel]="studioSelectedIdsModel()"
+          (ngModelChange)="onStudioSelectionChanged($event)"
+          (onFilter)="onStudioFilterChanged($event.filter)"
+          (onPanelHide)="onStudioFilterPanelHide()"
+          [filter]="true"
+          [filterValue]="studioSearchTerm()"
+          filterPlaceHolder="Search local studios"
+          [loading]="studioSearchLoading()"
+          [options]="studioSelectOptions()"
+          optionLabel="label"
+          optionValue="value"
+          [showToggleAll]="false"
+          display="chip"
+          [emptyMessage]="studioSelectEmptyMessage()"
+          [emptyFilterMessage]="studioSelectEmptyMessage()"
+          [resetFilterOnHide]="true"
+          [appendTo]="'body'"
+          panelStyleClass="library-filter-panel"
+          placeholder="Choose local studios"
+          scrollHeight="16rem"
+        />
+      </label>
+
+      <label class="control-field control-field--tag">
+        <span>Tag Filter</span>
+        <div class="tag-input-row">
           <p-multiselect
-            inputId="library-studios"
-            [ngModel]="studioSelectedIdsModel()"
-            (ngModelChange)="onStudioSelectionChanged($event)"
-            (onFilter)="onStudioFilterChanged($event.filter)"
-            (onPanelHide)="onStudioFilterPanelHide()"
+            inputId="library-tags"
+            [ngModel]="selectedTagIdsModel()"
+            (ngModelChange)="onTagSelectionChanged($event)"
+            (onFilter)="onTagFilterChanged($event.filter)"
+            (onPanelHide)="onTagFilterPanelHide()"
             [filter]="true"
-            [filterValue]="studioSearchTerm()"
-            filterPlaceHolder="Search local studios"
-            [loading]="studioSearchLoading()"
-            [options]="studioSelectOptions()"
+            [filterValue]="tagSearchTerm()"
+            filterPlaceHolder="Search local tags"
+            [loading]="tagSearchLoading()"
+            [options]="tagSelectOptions()"
             optionLabel="label"
             optionValue="value"
             [showToggleAll]="false"
             display="chip"
-            [emptyMessage]="studioSelectEmptyMessage()"
-            [emptyFilterMessage]="studioSelectEmptyMessage()"
+            [emptyMessage]="tagSelectEmptyMessage()"
+            [emptyFilterMessage]="tagSelectEmptyMessage()"
             [resetFilterOnHide]="true"
             [appendTo]="'body'"
             panelStyleClass="library-filter-panel"
-            placeholder="Choose local studios"
+            placeholder="Select matching tags"
             scrollHeight="16rem"
           />
-        </label>
-      </article>
-
-      <article class="control-card">
-        <label class="control-field">
-          <span class="field-label-row">
-            <span>Tag Filter</span>
-            <span
-              class="info-hint pi pi-info-circle"
-              [attr.title]="tagModeTooltip()"
-              aria-hidden="true"
-            ></span>
-          </span>
-          <div class="tag-input-row">
-            <p-multiselect
-              inputId="library-tags"
-              [ngModel]="selectedTagIdsModel()"
-              (ngModelChange)="onTagSelectionChanged($event)"
-              (onFilter)="onTagFilterChanged($event.filter)"
-              (onPanelHide)="onTagFilterPanelHide()"
-              [filter]="true"
-              [filterValue]="tagSearchTerm()"
-              filterPlaceHolder="Search local tags"
-              [loading]="tagSearchLoading()"
-              [options]="tagSelectOptions()"
-              optionLabel="label"
-              optionValue="value"
-              [showToggleAll]="false"
-              display="chip"
-              [emptyMessage]="tagSelectEmptyMessage()"
-              [emptyFilterMessage]="tagSelectEmptyMessage()"
-              [resetFilterOnHide]="true"
-              [appendTo]="'body'"
-              panelStyleClass="library-filter-panel"
-              placeholder="Select matching tags"
-              scrollHeight="16rem"
-            />
-            <p-select
-              class="tag-mode-select"
-              inputId="library-tag-mode"
-              [ngModel]="selectedTagMode()"
-              (ngModelChange)="onTagMatchModeChanged($event)"
-              [options]="tagMatchOptions"
-              optionLabel="label"
-              optionValue="value"
-              [appendTo]="'body'"
-              panelStyleClass="library-filter-select-panel"
-            />
-          </div>
-        </label>
-      </article>
-
-      <article class="control-card">
-        <div class="control-field">
-          <span class="field-label-row">
-            <span>Sort Order</span>
-            <span
-              class="info-hint pi pi-info-circle"
-              [attr.title]="'Current sort: ' + sortSummary()"
-              aria-hidden="true"
-            ></span>
-          </span>
-          <div class="sort-with-direction">
-            <p-select
-              inputId="library-sort"
-              [ngModel]="selectedSort()"
-              (ngModelChange)="onSortChanged($event)"
-              [options]="sortOptions"
-              optionLabel="label"
-              optionValue="value"
-              [appendTo]="'body'"
-              panelStyleClass="library-filter-select-panel"
-            />
-            <button
-              type="button"
-              class="sort-direction-toggle"
-              [attr.aria-label]="sortDirectionToggleLabel()"
-              [attr.title]="sortDirectionToggleLabel()"
-              (click)="toggleSortDirection()"
-            >
-              <i [class]="sortDirectionIconClass()" aria-hidden="true"></i>
-            </button>
-          </div>
+          <p-select
+            class="tag-mode-select"
+            inputId="library-tag-mode"
+            [ngModel]="selectedTagMode()"
+            (ngModelChange)="onTagMatchModeChanged($event)"
+            [options]="tagMatchOptions"
+            optionLabel="label"
+            optionValue="value"
+            [appendTo]="'body'"
+            panelStyleClass="library-filter-select-panel"
+          />
         </div>
-      </article>
+      </label>
 
-      <article class="control-card favorites-card">
-        <div class="control-field">
-          <span class="field-label-row">
-            <span>Local Favorite Overlays</span>
-            <span
-              class="info-hint pi pi-info-circle"
-              [attr.title]="favoriteOverlayTooltip()"
-              aria-hidden="true"
-            ></span>
-          </span>
-          <div class="local-favorites-toggles">
-            <button
-              type="button"
-              class="filter-toggle"
-              [class.is-active]="favoritePerformersOnly()"
-              [attr.aria-pressed]="favoritePerformersOnly()"
-              (click)="onFavoritePerformersOnlyChanged(!favoritePerformersOnly())"
-            >
-              Favorite performers
-            </button>
-            <button
-              type="button"
-              class="filter-toggle"
-              [class.is-active]="favoriteStudiosOnly()"
-              [attr.aria-pressed]="favoriteStudiosOnly()"
-              (click)="onFavoriteStudiosOnlyChanged(!favoriteStudiosOnly())"
-            >
-              Favorite studios
-            </button>
-            <button
-              type="button"
-              class="filter-toggle"
-              [class.is-active]="favoriteTagsOnly()"
-              [attr.aria-pressed]="favoriteTagsOnly()"
-              (click)="onFavoriteTagsOnlyChanged(!favoriteTagsOnly())"
-            >
-              Favorite tags
-            </button>
-          </div>
-        </div>
-      </article>
-    </div>
-  </section>
-
-  <section class="results-shell">
-    <div class="results-head">
-      <div class="results-copy">
-        <p class="eyebrow">Local Results</p>
-        <h2>{{ resultsHeading() }}</h2>
-        <p>{{ resultsSummary() }}</p>
-      </div>
-
-      <div class="results-actions">
-        @if (hasActiveFilters()) {
-          <button type="button" class="secondary-action" (click)="resetFilters()">
-            Clear filters
+      <div class="control-field control-field--sort">
+        <span>Sort By</span>
+        <div class="sort-with-direction">
+          <p-select
+            inputId="library-sort"
+            [ngModel]="selectedSort()"
+            (ngModelChange)="onSortChanged($event)"
+            [options]="sortOptions"
+            optionLabel="label"
+            optionValue="value"
+            [appendTo]="'body'"
+            panelStyleClass="library-filter-select-panel"
+          />
+          <button
+            type="button"
+            class="sort-direction-toggle"
+            [attr.aria-label]="sortDirectionToggleLabel()"
+            [attr.title]="sortDirectionToggleLabel()"
+            (click)="toggleSortDirection()"
+          >
+            <i [class]="sortDirectionIconClass()" aria-hidden="true"></i>
           </button>
-        }
-        <a class="secondary-link small" [routerLink]="['/scenes']">Browse Discovery</a>
+        </div>
+      </div>
+
+      <div class="control-field control-field--favorites">
+        <span>Local Favorite Overlays</span>
+        <div class="local-favorites-toggles">
+          <button
+            type="button"
+            class="filter-toggle"
+            [class.is-active]="favoritePerformersOnly()"
+            [attr.aria-pressed]="favoritePerformersOnly()"
+            (click)="onFavoritePerformersOnlyChanged(!favoritePerformersOnly())"
+          >
+            Favorite performers
+          </button>
+          <button
+            type="button"
+            class="filter-toggle"
+            [class.is-active]="favoriteStudiosOnly()"
+            [attr.aria-pressed]="favoriteStudiosOnly()"
+            (click)="onFavoriteStudiosOnlyChanged(!favoriteStudiosOnly())"
+          >
+            Favorite studios
+          </button>
+          <button
+            type="button"
+            class="filter-toggle"
+            [class.is-active]="favoriteTagsOnly()"
+            [attr.aria-pressed]="favoriteTagsOnly()"
+            (click)="onFavoriteTagsOnlyChanged(!favoriteTagsOnly())"
+          >
+            Favorite tags
+          </button>
+        </div>
       </div>
     </div>
+
+    <p class="controls-note">{{ libraryControlsNote() }}</p>
 
     @if (hasNarrowingFilters()) {
       <div class="active-filters" data-testid="library-active-filters">
         <span class="active-filters-label">Active filters</span>
         <div class="active-filters-list">
           @if (queryTerm().trim().length > 0) {
-            <button type="button" class="filter-chip is-active" (click)="clearQueryFilter()">
+            <button type="button" class="filter-chip" (click)="clearQueryFilter()">
               {{ queryFilterLabel() }}
               <i class="pi pi-times" aria-hidden="true"></i>
             </button>
           }
 
           @for (studio of selectedStudios(); track studio.id) {
-            <button
-              type="button"
-              class="filter-chip is-active"
-              (click)="clearStudioFilter(studio.id)"
-            >
+            <button type="button" class="filter-chip" (click)="clearStudioFilter(studio.id)">
               Studio: {{ studio.label }}
               <i class="pi pi-times" aria-hidden="true"></i>
             </button>
           }
 
           @for (tag of selectedTags(); track tag.id) {
-            <button type="button" class="filter-chip is-active" (click)="clearTagFilter(tag.id)">
+            <button type="button" class="filter-chip" (click)="clearTagFilter(tag.id)">
               Tag: {{ tag.name }}
               <i class="pi pi-times" aria-hidden="true"></i>
             </button>
           }
 
           @if (favoritePerformersOnly()) {
-            <button
-              type="button"
-              class="filter-chip is-active"
-              (click)="clearFavoritePerformersFilter()"
-            >
+            <button type="button" class="filter-chip" (click)="clearFavoritePerformersFilter()">
               Favorite performers
               <i class="pi pi-times" aria-hidden="true"></i>
             </button>
           }
 
           @if (favoriteStudiosOnly()) {
-            <button
-              type="button"
-              class="filter-chip is-active"
-              (click)="clearFavoriteStudiosFilter()"
-            >
+            <button type="button" class="filter-chip" (click)="clearFavoriteStudiosFilter()">
               Favorite studios
               <i class="pi pi-times" aria-hidden="true"></i>
             </button>
           }
 
           @if (favoriteTagsOnly()) {
-            <button
-              type="button"
-              class="filter-chip is-active"
-              (click)="clearFavoriteTagsFilter()"
-            >
+            <button type="button" class="filter-chip" (click)="clearFavoriteTagsFilter()">
               Favorite tags
               <i class="pi pi-times" aria-hidden="true"></i>
             </button>
@@ -322,80 +225,72 @@
         </div>
       </div>
     }
-
-    @if (loading()) {
-      <div class="app-blocking-loader" role="status" aria-live="polite">
-        <p-progressspinner
-          styleClass="app-blocking-spinner"
-          strokeWidth="4"
-          [style]="{ width: '2.25rem', height: '2.25rem' }"
-        />
-        <p>Loading local library...</p>
-      </div>
-    } @else if (error()) {
-      <section class="state-shell">
-        <p-message severity="error" styleClass="app-page-message">{{ error() }}</p-message>
-        <button type="button" class="secondary-action" (click)="retryInitialLoad()">Retry</button>
-      </section>
-    } @else if (!hasItems()) {
-      <section class="state-shell empty-shell" data-testid="library-empty-state">
-        <p class="eyebrow">{{ emptyStateEyebrow() }}</p>
-        <h2>{{ emptyStateTitle() }}</h2>
-        <p class="state-copy">{{ emptyStateMessage() }}</p>
-
-        <div class="state-actions">
-          @if (hasNarrowingFilters()) {
-            <button type="button" class="secondary-action" (click)="resetFilters()">
-              Clear filters
-            </button>
-            <a class="primary-link" [routerLink]="['/scenes']">Browse Scenes</a>
-            <a class="secondary-link" [routerLink]="['/acquisition']">Track Imports</a>
-          } @else {
-            <a class="primary-link" [routerLink]="['/acquisition']">Track Imports</a>
-            <a class="secondary-link" [routerLink]="['/scenes']">Browse Scenes</a>
-            @if (pageAlert()) {
-              <a class="secondary-link" [routerLink]="['/settings']">Open Settings</a>
-            }
-          }
-        </div>
-      </section>
-    } @else {
-      <section class="grid">
-        @for (item of items(); track item.id) {
-          <app-scene-card
-            [item]="item"
-            [primaryLinkMode]="item.activeCatalogSceneId ? 'scene' : 'external'"
-            [sceneRouteId]="item.activeCatalogSceneId"
-            [sceneQueryParams]="item.activeCatalogSceneId ? { returnTo: currentRouteUrl() } : null"
-            [externalHref]="item.activeCatalogSceneId ? null : item.viewUrl"
-            studioBadgeRoute="library"
-            [topBadges]="localCardBadges"
-            [footerLink]="libraryFooterLink(item)"
-            [footerLinkLabel]="item.activeCatalogSceneId ? 'View in Stash' : null"
-            [footerBadgeLabel]="item.activeCatalogSceneId ? null : 'Local only'"
-          />
-        }
-      </section>
-
-      <div #loadMoreSentinel class="load-sentinel"></div>
-
-      @if (loadingMore()) {
-        <div class="app-blocking-loader inline" role="status" aria-live="polite">
-          <p-progressspinner
-            styleClass="app-blocking-spinner"
-            strokeWidth="4"
-            [style]="{ width: '2rem', height: '2rem' }"
-          />
-          <p>Loading more local scenes...</p>
-        </div>
-      }
-
-      @if (loadMoreError()) {
-        <div class="load-more-error">
-          <p-message severity="error" styleClass="app-page-message">{{ loadMoreError() }}</p-message>
-          <button type="button" class="secondary-action" (click)="retryLoadMore()">Retry</button>
-        </div>
-      }
-    }
   </section>
+
+  @if (loading()) {
+    <div class="app-blocking-loader" role="status" aria-live="polite">
+      <p-progressspinner
+        styleClass="app-blocking-spinner"
+        strokeWidth="4"
+        [style]="{ width: '2.25rem', height: '2.25rem' }"
+      />
+      <p>Loading local library...</p>
+    </div>
+  } @else if (error()) {
+    <p-message severity="error" styleClass="app-page-message">{{ error() }}</p-message>
+    <button type="button" class="retry-button" (click)="retryInitialLoad()">Retry</button>
+  } @else if (!hasItems()) {
+    <section class="state-shell empty-shell" data-testid="library-empty-state">
+      <h2>{{ emptyStateTitle() }}</h2>
+      <p class="state-copy">{{ emptyStateMessage() }}</p>
+
+      <div class="state-actions">
+        @if (hasNarrowingFilters()) {
+          <button type="button" class="secondary-link" (click)="resetFilters()">
+            Clear filters
+          </button>
+          <a class="primary-link" [routerLink]="['/scenes']">Browse Scenes</a>
+          <a class="secondary-link" [routerLink]="['/acquisition']">Track Imports</a>
+        } @else {
+          <a class="primary-link" [routerLink]="['/acquisition']">Track Imports</a>
+          <a class="secondary-link" [routerLink]="['/scenes']">Browse Scenes</a>
+          @if (pageAlert()) {
+            <a class="secondary-link" [routerLink]="['/settings']">Open Settings</a>
+          }
+        }
+      </div>
+    </section>
+  } @else {
+    <section class="grid">
+      @for (item of items(); track item.id) {
+        <app-scene-card
+          [item]="item"
+          [primaryLinkMode]="item.activeCatalogSceneId ? 'scene' : 'external'"
+          [sceneRouteId]="item.activeCatalogSceneId"
+          [sceneQueryParams]="item.activeCatalogSceneId ? { returnTo: currentRouteUrl() } : null"
+          [externalHref]="item.activeCatalogSceneId ? null : item.viewUrl"
+          studioBadgeRoute="library"
+          [topBadges]="localCardBadges"
+          [footerLink]="libraryFooterLink(item)"
+          [footerLinkLabel]="item.activeCatalogSceneId ? 'View in Stash' : null"
+          [footerBadgeLabel]="item.activeCatalogSceneId ? null : 'Local only'"
+        />
+      }
+    </section>
+
+    <div #loadMoreSentinel class="load-sentinel"></div>
+
+    @if (loadingMore()) {
+      <p class="state">Loading more local scenes...</p>
+    }
+
+    @if (loadMoreError()) {
+      <div class="load-more-error">
+        <p-message severity="error" styleClass="app-inline-message">{{
+          loadMoreError()
+        }}</p-message>
+        <button type="button" class="retry-button" (click)="retryLoadMore()">Retry</button>
+      </div>
+    }
+  }
 </main>

--- a/apps/sp-web/src/app/pages/library/library-page.component.scss
+++ b/apps/sp-web/src/app/pages/library/library-page.component.scss
@@ -3,29 +3,20 @@
   min-height: 100dvh;
   color: var(--text-primary);
   font-family: var(--app-font-family);
-  --lib-panel-border: color-mix(in srgb, var(--border-strong) 54%, transparent);
-  --lib-panel-bg: color-mix(in srgb, var(--surface-elevated) 94%, var(--surface-1));
-  --lib-card-border: color-mix(in srgb, var(--border-strong) 52%, transparent);
-  --lib-soft-border: color-mix(in srgb, var(--border-strong) 48%, transparent);
-  --lib-soft-bg: color-mix(in srgb, var(--surface-1) 96%, var(--surface-elevated));
-  --lib-chip-border: color-mix(in srgb, var(--border-strong) 66%, transparent);
-  --lib-chip-bg: color-mix(in srgb, var(--chip-bg) 80%, var(--surface-elevated));
-  --lib-accent-border: color-mix(in srgb, var(--focus-ring) 50%, transparent);
-  --lib-accent-bg: color-mix(in srgb, var(--focus-ring) 16%, var(--surface-elevated));
-  --lib-accent-bg-soft: color-mix(in srgb, var(--focus-ring) 14%, var(--surface-elevated));
-  --lib-accent-copy: color-mix(in srgb, var(--focus-ring) 82%, var(--text-primary));
-  --lib-dashed-border: color-mix(in srgb, var(--border-strong) 60%, transparent);
+  --library-chip-border: color-mix(in srgb, var(--border-strong) 62%, transparent);
+  --library-accent-border: color-mix(in srgb, var(--focus-ring) 48%, transparent);
+  --library-accent-bg: color-mix(in srgb, var(--focus-ring) 16%, var(--surface-elevated));
+  --library-accent-text: color-mix(in srgb, var(--focus-ring) 82%, var(--text-primary));
 }
 
 main {
-  max-width: min(1380px, 96vw);
+  max-width: min(1540px, 96vw);
   margin: 0 auto;
-  padding: 1.25rem 1rem 1.8rem;
+  padding: 1.2rem 1rem 1.5rem;
 }
 
 h1,
 h2,
-h3,
 p {
   margin: 0;
 }
@@ -34,211 +25,129 @@ a {
   color: inherit;
 }
 
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.72rem;
-  font-weight: 700;
-  color: color-mix(in srgb, var(--focus-ring) 68%, var(--text-primary));
-}
-
-.page-head,
-.summary-shell,
-.page-alert,
-.controls-shell,
-.results-shell {
-  margin-top: 1.05rem;
-}
-
-.page-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: end;
-  gap: 1rem;
-}
-
-.page-copy {
-  display: grid;
-  gap: 0.4rem;
-}
-
-.page-copy p:last-child {
+header p {
+  margin-top: 0.5rem;
   max-width: 66ch;
+}
+
+.state {
+  margin-top: 1rem;
   color: var(--text-muted);
-  line-height: 1.55;
-}
-
-.page-head-actions,
-.page-alert-actions,
-.results-actions,
-.state-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-}
-
-.page-head-actions {
-  justify-content: flex-end;
-}
-
-.summary-shell {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
-}
-
-.summary-card {
-  border-radius: 20px;
-  border: 1px solid var(--lib-panel-border);
-  padding: 0.9rem 1rem;
-  background:
-    linear-gradient(
-      160deg,
-      color-mix(in srgb, var(--surface-elevated) 96%, #fff),
-      color-mix(in srgb, var(--surface-raised) 76%, var(--surface-1))
-    );
-  box-shadow: var(--shadow-sm);
-  display: grid;
-  gap: 0.3rem;
-}
-
-.summary-card-label {
-  font-size: 0.76rem;
-  font-weight: 700;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.summary-card-head {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.38rem;
-}
-
-.summary-card-value {
-  font-size: clamp(1.35rem, 2.2vw, 1.95rem);
-  line-height: 1.1;
-}
-
-.summary-card-meta {
-  color: var(--text-muted);
-  font-size: 0.78rem;
-  line-height: 1.35;
-}
-
-.info-hint {
-  color: var(--text-muted);
-  font-size: 0.78rem;
-  cursor: help;
-  text-transform: none;
-  letter-spacing: 0;
 }
 
 .page-alert {
+  margin-top: 0.9rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 10px;
   border: 1px solid color-mix(in srgb, var(--warning-border) 82%, var(--border-strong));
-  border-radius: 20px;
-  padding: 1rem 1.1rem;
+  background: color-mix(in srgb, var(--warning-bg) 42%, var(--surface-1));
   display: flex;
-  justify-content: space-between;
   align-items: start;
-  gap: 1rem;
-  background: color-mix(in srgb, var(--warning-bg) 56%, var(--surface-elevated));
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .page-alert-copy {
   display: grid;
-  gap: 0.36rem;
+  gap: 0.32rem;
+}
+
+.page-alert-title {
+  font-size: 0.96rem;
+  font-weight: 700;
 }
 
 .page-alert-copy p:last-child {
   color: var(--text-muted);
-  line-height: 1.55;
-  max-width: 68ch;
+  line-height: 1.52;
+  max-width: 72ch;
 }
 
-.controls-shell,
-.results-shell {
-  border: 1px solid var(--lib-panel-border);
-  border-radius: 24px;
-  padding: 1rem;
-  background: var(--lib-panel-bg);
-}
-
-.controls-overview,
-.results-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: start;
-  gap: 1rem;
-}
-
-.controls-overview > div:first-child,
-.results-copy {
+.controls-shell {
+  margin-top: 0.9rem;
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-1);
   display: grid;
-  gap: 0.34rem;
+  gap: 0.65rem;
 }
 
-.results-copy p:last-child {
-  color: var(--text-muted);
-  line-height: 1.55;
-  max-width: 68ch;
+.controls-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
-.controls-grid {
-  margin-top: 0.95rem;
+.page-alert-actions,
+.controls-actions,
+.state-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.controls-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+
+.controls-row {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 0.75rem;
-}
-
-.control-card {
-  grid-column: span 4;
-  border-radius: 18px;
-  border: 1px solid var(--lib-soft-border);
-  padding: 0.9rem;
-  background: var(--lib-soft-bg);
-  display: grid;
-  gap: 0.55rem;
-}
-
-.search-card {
-  grid-column: span 5;
-}
-
-.favorites-card {
-  grid-column: span 8;
+  gap: 0.6rem;
+  align-items: start;
 }
 
 .control-field {
   display: grid;
-  gap: 0.34rem;
+  gap: 0.26rem;
   min-width: 0;
 }
 
 .control-field > span {
-  font-size: 0.75rem;
-  letter-spacing: 0.04em;
+  font-size: 0.74rem;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
   color: var(--text-muted);
   font-weight: 700;
 }
 
-.field-label-row {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.38rem;
+.control-field--query {
+  grid-column: span 4;
+}
+
+.control-field--studio,
+.control-field--tag {
+  grid-column: span 3;
+}
+
+.control-field--sort {
+  grid-column: span 2;
+}
+
+.control-field--favorites {
+  grid-column: 1 / -1;
 }
 
 .control-field input {
   width: 100%;
+  min-height: 2.5rem;
   box-sizing: border-box;
-  border-radius: 10px;
+  border-radius: 7px;
   border: 1px solid var(--border-strong);
-  background: var(--surface-1);
+  background: var(--surface-elevated);
   color: var(--text-primary);
-  font-size: 0.92rem;
-  padding: 0.74rem 0.8rem;
+  font-size: 0.85rem;
+  padding: 0.38rem 0.44rem;
 }
 
 .control-field input:focus {
@@ -249,8 +158,8 @@ a {
 
 .tag-input-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 8.75rem);
-  gap: 0.45rem;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 8.5rem);
+  gap: 0.35rem;
   align-items: center;
   min-width: 0;
 }
@@ -262,25 +171,26 @@ a {
 .sort-with-direction {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.42rem;
+  gap: 0.35rem;
   align-items: center;
   min-width: 0;
 }
 
 .sort-direction-toggle,
-.secondary-action,
+.reset-filters-button,
 .filter-toggle,
-.filter-chip {
+.filter-chip,
+.retry-button {
   font: inherit;
 }
 
 .sort-direction-toggle {
-  width: 2.7rem;
-  min-width: 2.7rem;
-  height: 2.7rem;
-  border-radius: 10px;
+  width: 2.5rem;
+  min-width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 7px;
   border: 1px solid var(--border-strong);
-  background: var(--surface-1);
+  background: var(--surface-elevated);
   color: var(--text-primary);
   display: grid;
   place-items: center;
@@ -294,110 +204,130 @@ a {
 .local-favorites-toggles {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
+  gap: 0.45rem;
 }
 
 .filter-toggle {
-  min-height: 2.7rem;
+  min-height: 2.5rem;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--border-strong) 72%, transparent);
-  background: color-mix(in srgb, var(--surface-1) 96%, var(--surface-elevated));
-  color: var(--text-primary);
-  font-size: 0.86rem;
-  font-weight: 600;
-  padding: 0.6rem 0.9rem;
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  color: var(--button-text);
+  padding: 0.38rem 0.68rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   cursor: pointer;
-  transition:
-    transform 140ms ease,
-    border-color 140ms ease,
-    background 140ms ease;
-}
-
-.filter-toggle:hover {
-  transform: translateY(-1px);
 }
 
 .filter-toggle.is-active {
-  border-color: var(--lib-accent-border);
-  background: var(--lib-accent-bg);
-  color: var(--lib-accent-copy);
+  border-color: var(--library-accent-border);
+  background: var(--library-accent-bg);
+  color: var(--library-accent-text);
 }
 
-:host ::ng-deep .controls-shell .p-select,
-:host ::ng-deep .controls-shell .p-multiselect {
-  width: 100%;
+.reset-filters-button {
+  padding: 0.38rem 0.68rem;
+  border-radius: 999px;
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  color: var(--button-text);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
 }
 
-:host ::ng-deep .controls-shell .p-select,
-:host ::ng-deep .controls-shell .p-multiselect {
-  border-radius: 10px;
-  border-color: var(--border-strong);
-  background: var(--surface-1);
-  color: var(--text-primary);
+.reset-filters-button:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
-:host ::ng-deep .controls-shell .p-select.p-focus,
-:host ::ng-deep .controls-shell .p-multiselect.p-focus {
-  border-color: var(--focus-ring);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--focus-ring) 44%, transparent);
-}
-
-.results-shell {
-  display: grid;
-  gap: 0.8rem;
+.controls-note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
 }
 
 .active-filters {
-  display: grid;
-  gap: 0.55rem;
-  padding: 0.85rem 0.9rem;
-  border-radius: 18px;
-  border: 1px dashed var(--lib-dashed-border);
-  background: var(--lib-soft-bg);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem 0.5rem;
 }
 
 .active-filters-label {
-  font-size: 0.76rem;
+  font-size: 0.72rem;
   font-weight: 700;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
   color: var(--text-muted);
 }
 
 .active-filters-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 .filter-chip {
-  border: 1px solid var(--lib-chip-border);
+  border: 1px solid var(--library-chip-border);
   border-radius: 999px;
-  background: var(--chip-bg);
-  color: var(--chip-text);
+  background: var(--surface-elevated);
+  color: var(--text-primary);
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.4rem 0.72rem;
+  gap: 0.35rem;
+  padding: 0.28rem 0.58rem;
+  font-size: 0.78rem;
   cursor: pointer;
 }
 
-.filter-chip.is-active {
-  font-weight: 600;
+.filter-chip i {
+  font-size: 0.72rem;
+}
+
+:host ::ng-deep .controls-shell .p-select,
+:host ::ng-deep .controls-shell .p-inputtext,
+:host ::ng-deep .controls-shell .p-multiselect {
+  width: 100%;
+}
+
+:host ::ng-deep .controls-shell .p-select,
+:host ::ng-deep .controls-shell .p-inputtext,
+:host ::ng-deep .controls-shell .p-multiselect {
+  min-height: 2.5rem;
+  border-radius: 7px;
+  border-color: var(--border-strong);
+  background: var(--surface-elevated);
+  color: var(--text-primary);
+}
+
+:host ::ng-deep .controls-shell .p-select.p-focus,
+:host ::ng-deep .controls-shell .p-inputtext:focus,
+:host ::ng-deep .controls-shell .p-multiselect.p-focus {
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--focus-ring) 44%, transparent);
+}
+
+:host ::ng-deep .controls-shell .p-multiselect-label-container {
+  min-width: 0;
+}
+
+:host ::ng-deep .controls-shell .p-multiselect-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .state-shell {
-  border: 1px dashed var(--lib-dashed-border);
-  border-radius: 20px;
-  padding: 1.25rem;
-  background: var(--lib-soft-bg);
+  margin-top: 0.9rem;
+  padding: 1rem;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-1);
   display: grid;
-  gap: 0.8rem;
+  gap: 0.65rem;
   justify-items: start;
-}
-
-.empty-shell {
-  padding: 1.4rem 1.25rem;
 }
 
 .state-copy {
@@ -406,123 +336,96 @@ a {
   color: var(--text-muted);
 }
 
-.grid {
-  display: grid;
-  gap: 0.72rem;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-}
-
 .primary-link,
-.secondary-link,
-.secondary-action {
-  min-height: 2.45rem;
+.secondary-link {
+  font: inherit;
+  min-height: 2.25rem;
+  padding: 0.42rem 0.72rem;
   border-radius: 999px;
-  padding: 0.56rem 0.95rem;
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  color: var(--button-text);
+  font-size: 0.74rem;
   font-weight: 700;
+  letter-spacing: 0.02em;
   text-decoration: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition:
-    transform 140ms ease,
-    border-color 140ms ease,
-    background 140ms ease;
-}
-
-.primary-link:hover,
-.secondary-link:hover,
-.secondary-action:hover {
-  transform: translateY(-1px);
-}
-
-.primary-link {
-  border: 1px solid var(--lib-accent-border);
-  background: var(--lib-accent-bg);
-  color: var(--lib-accent-copy);
-}
-
-.secondary-link,
-.secondary-action {
-  border: 1px solid var(--lib-chip-border);
-  background: var(--lib-soft-bg);
-  color: var(--text-primary);
-}
-
-.secondary-action {
   cursor: pointer;
 }
 
-.secondary-action:disabled {
-  opacity: 0.55;
-  cursor: default;
-  transform: none;
+.primary-link {
+  border-color: var(--library-accent-border);
+  background: var(--library-accent-bg);
+  color: var(--library-accent-text);
 }
 
 .small {
-  min-height: 2.2rem;
-  padding: 0.46rem 0.82rem;
-  font-size: 0.84rem;
+  min-height: 2.1rem;
+  padding: 0.36rem 0.64rem;
+}
+
+.grid {
+  margin-top: 0.9rem;
+  display: grid;
+  gap: 0.72rem;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 }
 
 .load-sentinel {
   height: 1px;
 }
 
+.retry-button {
+  margin-top: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  color: var(--button-text);
+  cursor: pointer;
+}
+
 .load-more-error {
-  display: grid;
-  gap: 0.5rem;
-  justify-items: start;
+  margin-top: 0.5rem;
 }
 
 .sort-direction-toggle:focus-visible,
+.reset-filters-button:focus-visible,
 .filter-toggle:focus-visible,
 .filter-chip:focus-visible,
 .primary-link:focus-visible,
 .secondary-link:focus-visible,
-.secondary-action:focus-visible {
+.retry-button:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
 
-@media (max-width: 1120px) {
-  .summary-shell {
-    grid-template-columns: 1fr;
-  }
-
-  .controls-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .control-card,
-  .search-card,
-  .favorites-card {
-    grid-column: auto;
+@media (max-width: 1180px) {
+  .control-field--query,
+  .control-field--studio,
+  .control-field--tag,
+  .control-field--sort {
+    grid-column: span 6;
   }
 }
 
 @media (max-width: 760px) {
-  .page-head,
-  .controls-overview,
-  .results-head,
   .page-alert {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .page-head-actions,
-  .results-actions {
-    justify-content: flex-start;
-  }
-
-  .controls-grid {
-    grid-template-columns: 1fr;
+  .control-field--query,
+  .control-field--studio,
+  .control-field--tag,
+  .control-field--sort,
+  .control-field--favorites {
+    grid-column: 1 / -1;
   }
 
   .tag-input-row {
-    grid-template-columns: 1fr;
-  }
-
-  .grid {
     grid-template-columns: 1fr;
   }
 }
@@ -532,15 +435,8 @@ a {
     padding-inline: 0.85rem;
   }
 
-  .controls-shell,
-  .results-shell,
-  .page-alert,
-  .state-shell {
-    padding: 0.9rem;
-  }
-
-  .control-card,
-  .summary-card {
-    padding: 0.85rem;
+  .grid {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
   }
 }

--- a/apps/sp-web/src/app/pages/library/library-page.component.spec.ts
+++ b/apps/sp-web/src/app/pages/library/library-page.component.spec.ts
@@ -134,14 +134,12 @@ describe('LibraryPageComponent', () => {
     TestBed.resetTestingModule();
   });
 
-  async function renderPage(
-    options?: {
-      initialQueryParams?: Record<string, string>;
-      feedResponse?: LibraryScenesFeedResponse;
-      runtimeHealth?: RuntimeHealthResponse;
-      setupStatus?: SetupStatusResponse;
-    },
-  ) {
+  async function renderPage(options?: {
+    initialQueryParams?: Record<string, string>;
+    feedResponse?: LibraryScenesFeedResponse;
+    runtimeHealth?: RuntimeHealthResponse;
+    setupStatus?: SetupStatusResponse;
+  }) {
     const queryParamMap = convertToParamMap(options?.initialQueryParams ?? {});
     const queryParamMap$ = new BehaviorSubject(queryParamMap);
     const libraryService = {
@@ -205,7 +203,7 @@ describe('LibraryPageComponent', () => {
   it('loads the default local-library view from the dedicated library API', async () => {
     const { fixture, libraryService, navigateSpy, runtimeHealthService } = await renderPage();
     const resetButton = fixture.nativeElement.querySelector(
-      '.controls-overview .secondary-action',
+      '.controls-header .reset-filters-button',
     ) as HTMLButtonElement | null;
 
     expect(runtimeHealthService.ensureStarted).toHaveBeenCalledTimes(1);
@@ -238,14 +236,14 @@ describe('LibraryPageComponent', () => {
       },
     });
     const resetButton = fixture.nativeElement.querySelector(
-      '.controls-overview .secondary-action',
+      '.controls-header .reset-filters-button',
     ) as HTMLButtonElement | null;
 
     expect(resetButton).toBeTruthy();
     expect(resetButton?.disabled).toBe(false);
-    expect(fixture.nativeElement.querySelector('[data-testid="library-active-filters"]')?.textContent).toContain(
-      'Query: archive',
-    );
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="library-active-filters"]')?.textContent,
+    ).toContain('Query: archive');
 
     resetButton?.click();
     fixture.detectChanges();
@@ -329,7 +327,9 @@ describe('LibraryPageComponent', () => {
     ) as HTMLElement | null;
 
     expect(degradedAlert?.textContent).toContain('Local library freshness is degraded');
-    expect(degradedAlert?.textContent).toContain('Currently showing projected library data synced through');
+    expect(degradedAlert?.textContent).toContain(
+      'Currently showing projected library data synced through',
+    );
     expect(degradedAlert?.textContent).toContain('Newly imported scenes');
   });
 
@@ -358,18 +358,23 @@ describe('LibraryPageComponent', () => {
     ).toContain('Clear filters');
   });
 
-  it('keeps the normal library browsing state visually quiet', async () => {
+  it('uses the compact scenes-style shell while preserving local-library controls', async () => {
     const { fixture } = await renderPage({
       feedResponse: buildFeedResponse([buildScene({ description: null })]),
     });
-    const text = fixture.nativeElement.textContent;
 
-    expect(fixture.nativeElement.querySelector('.summary-card-copy')).toBeNull();
-    expect(fixture.nativeElement.querySelector('.control-note')).toBeNull();
-    expect(fixture.nativeElement.querySelector('.results-note')).toBeNull();
-    expect(fixture.nativeElement.querySelector('.card-description')).toBeNull();
-    expect(text).not.toContain('Metadata is sparse in Stash');
-    expect(text).not.toContain('Search stays local to the library projection');
+    expect(fixture.nativeElement.querySelector('.summary-shell')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.results-shell')).toBeNull();
+    expect(fixture.nativeElement.querySelector('header .state')?.textContent).toContain(
+      '1 local scene / Release newest',
+    );
+    expect(fixture.nativeElement.querySelector('.controls-note')?.textContent).toContain(
+      'Filters apply to indexed local scenes',
+    );
+    expect(fixture.nativeElement.querySelector('.controls-row input[type="search"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelectorAll('p-multiselect')).toHaveLength(2);
+    expect(fixture.nativeElement.querySelectorAll('p-select')).toHaveLength(2);
+    expect(fixture.nativeElement.querySelector('.grid')).toBeTruthy();
   });
 
   it('renders the shared compact scene card with minimal library-specific actions and badges', async () => {

--- a/apps/sp-web/src/app/pages/library/library-page.component.ts
+++ b/apps/sp-web/src/app/pages/library/library-page.component.ts
@@ -38,10 +38,7 @@ import {
   LibraryTagMatchMode,
   LibraryTagOption,
 } from '../../core/api/library.types';
-import {
-  SceneCardBadge,
-  SceneCardComponent,
-} from '../../shared/scene-card/scene-card.component';
+import { SceneCardBadge, SceneCardComponent } from '../../shared/scene-card/scene-card.component';
 import { SceneCardShellLink } from '../../shared/scene-card/scene-card-shell.component';
 
 interface MultiSelectOption {
@@ -55,7 +52,6 @@ interface SelectedChip {
 }
 
 interface LibraryPageAlert {
-  eyebrow: string;
   title: string;
   message: string;
 }
@@ -181,7 +177,6 @@ export class LibraryPageComponent implements OnInit, AfterViewInit, OnDestroy {
     const setupStatus = this.setupStatusStore.status();
     if (setupStatus && !setupStatus.required.stash) {
       return {
-        eyebrow: 'Repair Required',
         title: 'Local library browsing needs attention',
         message:
           'Stash needs repair for this surface. Newly imported scenes, artwork, and local favorite overlays may be missing or stale until the integration is fixed.',
@@ -198,7 +193,6 @@ export class LibraryPageComponent implements OnInit, AfterViewInit, OnDestroy {
       : 'Currently showing projected library data with an unknown sync timestamp.';
 
     return {
-      eyebrow: 'Runtime Outage',
       title: 'Local library freshness is degraded',
       message: `${freshnessHint} Newly imported scenes, refreshed metadata, and availability overlays may lag until Stash is healthy again.`,
     };
@@ -358,14 +352,6 @@ export class LibraryPageComponent implements OnInit, AfterViewInit, OnDestroy {
     this.resetFeedAndReload();
   }
 
-  protected totalSummaryValue(): string {
-    if (this.loading() && this.total() === 0) {
-      return 'Loading...';
-    }
-
-    return this.total().toLocaleString();
-  }
-
   protected activeFilterCount(): number {
     return (
       (this.queryTerm().trim().length > 0 ? 1 : 0) +
@@ -377,97 +363,17 @@ export class LibraryPageComponent implements OnInit, AfterViewInit, OnDestroy {
     );
   }
 
-  protected viewSummaryValue(): string {
-    const count = this.activeFilterCount();
-    if (count === 0) {
-      return 'All scenes';
-    }
+  protected libraryStateLabel(): string {
+    const total = this.total();
+    const countLabel = this.hasNarrowingFilters()
+      ? `${total.toLocaleString()} ${total === 1 ? 'match' : 'matches'}`
+      : `${total.toLocaleString()} local scene${total === 1 ? '' : 's'}`;
 
-    return `${count} filter${count === 1 ? '' : 's'}`;
+    return `${countLabel} / ${this.sortSummaryShort()}`;
   }
 
-  protected viewSummaryMeta(): string {
-    return this.sortSummaryShort();
-  }
-
-  protected viewSummaryTooltip(): string {
-    const details = [`Sort: ${this.sortSummary()}.`];
-
-    if (this.selectedTags().length > 1) {
-      details.push(
-        this.selectedTagMode() === 'AND'
-          ? 'Selected tags must all match.'
-          : 'Selected tags can match in any combination.',
-      );
-    }
-
-    return details.join(' ');
-  }
-
-  protected freshnessSummaryValue(): string {
-    if (this.pageAlert()) {
-      return 'Needs attention';
-    }
-
-    const latestSyncAt = this.latestSyncAt();
-    if (latestSyncAt) {
-      return this.formatDateTime(latestSyncAt);
-    }
-
-    if (this.loading()) {
-      return 'Checking...';
-    }
-
-    return 'Awaiting sync';
-  }
-
-  protected freshnessSummaryTooltip(): string {
-    if (this.pageAlert()) {
-      return 'Stash is affecting how fresh this local view can be right now.';
-    }
-
-    const latestSyncAt = this.latestSyncAt();
-    if (latestSyncAt) {
-      return `Latest projection sync for this view: ${this.formatDateTime(latestSyncAt)}.`;
-    }
-
-    return 'Waiting for the local library projection to sync.';
-  }
-
-  protected indexedSummaryTooltip(): string {
-    return 'Scenes currently available in the local library projection.';
-  }
-
-  protected resultsHeading(): string {
-    if (this.loading()) {
-      return 'Loading local library';
-    }
-
-    if (this.error()) {
-      return 'Local library loading failed';
-    }
-
-    if (this.hasItems()) {
-      return 'Local scenes';
-    }
-
-    return this.emptyStateTitle();
-  }
-
-  protected resultsSummary(): string {
-    if (this.loading()) {
-      return 'Fetching scenes from the local library projection and applying the current local-first view.';
-    }
-
-    if (this.error()) {
-      return 'Retry the library feed to restore fast local browsing from the database-backed projection.';
-    }
-
-    if (this.hasItems()) {
-      return `${this.total().toLocaleString()} ${this.hasNarrowingFilters() ? 'matches' : 'scenes'} / ${this.sortSummaryShort()}`;
-    }
-
-    return this.emptyStateMessage();
+  protected libraryControlsNote(): string {
+    return 'Filters apply to indexed local scenes. Favorite overlay toggles use Stash favorites only.';
   }
 
   protected emptyStateTitle(): string {
@@ -482,30 +388,6 @@ export class LibraryPageComponent implements OnInit, AfterViewInit, OnDestroy {
       : 'This page only shows scenes that already exist in Stash. Import content, wait for indexing to finish, or browse discovery while your local library catches up.';
   }
 
-  protected emptyStateEyebrow(): string {
-    return this.hasNarrowingFilters() ? 'Filtered View' : 'Library Empty';
-  }
-
-  protected sortSummary(): string {
-    switch (this.selectedSort()) {
-      case 'TITLE':
-        return this.selectedDirection() === 'ASC' ? 'title, A to Z' : 'title, Z to A';
-      case 'CREATED_AT':
-        return this.selectedDirection() === 'ASC'
-          ? 'recently added, oldest first'
-          : 'recently added, newest first';
-      case 'UPDATED_AT':
-        return this.selectedDirection() === 'ASC'
-          ? 'recently updated, oldest first'
-          : 'recently updated, newest first';
-      case 'RELEASE_DATE':
-      default:
-        return this.selectedDirection() === 'ASC'
-          ? 'release date, oldest first'
-          : 'release date, newest first';
-    }
-  }
-
   protected sortSummaryShort(): string {
     switch (this.selectedSort()) {
       case 'TITLE':
@@ -518,20 +400,6 @@ export class LibraryPageComponent implements OnInit, AfterViewInit, OnDestroy {
       default:
         return this.selectedDirection() === 'ASC' ? 'Release oldest' : 'Release newest';
     }
-  }
-
-  protected tagModeTooltip(): string {
-    if (this.selectedTags().length <= 1) {
-      return 'Choose multiple tags to use AND or OR matching.';
-    }
-
-    return this.selectedTagMode() === 'AND'
-      ? 'Scenes must include every selected tag.'
-      : 'Scenes can include any selected tag.';
-  }
-
-  protected favoriteOverlayTooltip(): string {
-    return 'Applies local Stash favorite overlays only.';
   }
 
   protected queryFilterLabel(): string {


### PR DESCRIPTION
- remove dashboard-style summary and results chrome from /library

- compress the header, controls, active filters, and empty states to match /scenes rhythm

- preserve local-library filters and add targeted component coverage for the compact shell