### PR TITLE
feat(onboarding): harden first-run readiness flow

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: enymawse

--- a/apps/sp-web/src/app/features/auth/bootstrap-page.component.html
+++ b/apps/sp-web/src/app/features/auth/bootstrap-page.component.html
@@ -9,6 +9,7 @@
 
     <div class="auth-note">
       <p>This account signs into the app, unlocks setup, and can change its password later.</p>
+      <p>After this, Stasharr opens required integration setup for catalog, Stash, and Whisparr.</p>
       <p>Use a strong password now even if this is a private home network install.</p>
     </div>
 
@@ -20,12 +21,7 @@
 
       <label class="field">
         <span>Password</span>
-        <input
-          pInputText
-          type="password"
-          formControlName="password"
-          autocomplete="new-password"
-        />
+        <input pInputText type="password" formControlName="password" autocomplete="new-password" />
       </label>
 
       <label class="field">
@@ -48,8 +44,12 @@
         <p-message severity="error" styleClass="state-message">{{ errorMessage() }}</p-message>
       }
 
+      @if (handoffMessage()) {
+        <p-message severity="success" styleClass="state-message">{{ handoffMessage() }}</p-message>
+      }
+
       <button pButton type="submit" [disabled]="submitting()">
-        {{ submitting() ? 'Creating admin...' : 'Create admin account' }}
+        {{ submitting() ? 'Creating admin and opening setup...' : 'Create admin account' }}
       </button>
     </form>
   </section>

--- a/apps/sp-web/src/app/features/auth/bootstrap-page.component.spec.ts
+++ b/apps/sp-web/src/app/features/auth/bootstrap-page.component.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { AuthService } from '../../core/api/auth.service';
+import { BootstrapPageComponent } from './bootstrap-page.component';
+
+describe('BootstrapPageComponent', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('explains the setup handoff and navigates directly to setup after admin creation', async () => {
+    const authService = {
+      bootstrap: vi.fn().mockReturnValue(
+        of({
+          bootstrapRequired: false,
+          authenticated: true,
+          username: 'admin',
+        }),
+      ),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [BootstrapPageComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AuthService,
+          useValue: authService,
+        },
+      ],
+    }).compileComponents();
+
+    const router = TestBed.inject(Router);
+    const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    const fixture = TestBed.createComponent(BootstrapPageComponent);
+    const component = fixture.componentInstance as any;
+
+    fixture.detectChanges();
+
+    component.form.setValue({
+      username: 'admin',
+      password: 'long-password-123',
+      confirmPassword: 'long-password-123',
+    });
+    component.submit();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(authService.bootstrap).toHaveBeenCalledWith({
+      username: 'admin',
+      password: 'long-password-123',
+    });
+    expect(fixture.nativeElement.textContent).toContain(
+      'After this, Stasharr opens required integration setup',
+    );
+    expect(fixture.nativeElement.textContent).toContain(
+      'Admin account created. Opening required integration setup next.',
+    );
+    expect(navigate).toHaveBeenCalledWith(['/setup'], {
+      queryParams: {
+        from: 'bootstrap',
+      },
+    });
+  });
+});

--- a/apps/sp-web/src/app/features/auth/bootstrap-page.component.ts
+++ b/apps/sp-web/src/app/features/auth/bootstrap-page.component.ts
@@ -19,6 +19,7 @@ export class BootstrapPageComponent {
 
   protected readonly submitting = signal(false);
   protected readonly errorMessage = signal<string | null>(null);
+  protected readonly handoffMessage = signal<string | null>(null);
 
   protected readonly form = new FormGroup({
     username: new FormControl('', {
@@ -37,6 +38,7 @@ export class BootstrapPageComponent {
 
   protected submit(): void {
     this.errorMessage.set(null);
+    this.handoffMessage.set(null);
 
     if (this.form.invalid || this.passwordMismatch()) {
       this.form.markAllAsTouched();
@@ -49,7 +51,12 @@ export class BootstrapPageComponent {
     this.authService.bootstrap({ username, password }).subscribe({
       next: () => {
         this.submitting.set(false);
-        void this.router.navigateByUrl('/');
+        this.handoffMessage.set('Admin account created. Opening required integration setup next.');
+        void this.router.navigate(['/setup'], {
+          queryParams: {
+            from: 'bootstrap',
+          },
+        });
       },
       error: (error: unknown) => {
         this.submitting.set(false);

--- a/apps/sp-web/src/app/features/setup/setup-page.component.html
+++ b/apps/sp-web/src/app/features/setup/setup-page.component.html
@@ -1,7 +1,10 @@
 <main>
   <header>
     <h1>Stasharr Setup</h1>
-    <p>Finish the required integrations in order, keep the chosen catalog provider locked, and repair failures without guessing what is still blocking setup.</p>
+    <p>
+      Finish the required integrations in order, keep the chosen catalog provider locked, and repair
+      failures without guessing what is still blocking setup.
+    </p>
   </header>
 
   @if (loading()) {
@@ -16,6 +19,23 @@
   } @else if (loadError()) {
     <p-message severity="error" styleClass="app-page-message">{{ loadError() }}</p-message>
   } @else {
+    @if (bootstrapHandoff()) {
+      <section
+        class="handoff-panel app-page-alert"
+        data-testid="setup-bootstrap-handoff"
+        role="status"
+      >
+        <div class="handoff-copy app-page-alert__copy">
+          <p class="eyebrow">Admin account ready</p>
+          <h2>Connect the required integrations next</h2>
+          <p>
+            Setup locks in one catalog provider, then verifies Stash and Whisparr so the app can
+            open with working discovery, local library, and acquisition status.
+          </p>
+        </div>
+      </section>
+    }
+
     <section class="setup-overview">
       <div class="overview-head">
         <div>
@@ -49,10 +69,18 @@
                 [class.is-pending]="item.state === 'NOT_SAVED'"
               >
                 @switch (item.state) {
-                  @case ('NOT_SAVED') { Not Saved }
-                  @case ('SAVED') { Saved }
-                  @case ('TEST_FAILED') { Test Failed }
-                  @case ('READY') { Ready }
+                  @case ('NOT_SAVED') {
+                    Not Saved
+                  }
+                  @case ('SAVED') {
+                    Saved
+                  }
+                  @case ('TEST_FAILED') {
+                    Test Failed
+                  }
+                  @case ('READY') {
+                    Ready
+                  }
                 }
               </span>
             </div>
@@ -62,74 +90,93 @@
       </div>
     </section>
 
-    <section class="cards">
-      @for (type of visibleCatalogProviderTypes(); track type) {
-        <app-integration-repair-panel
-          class="card"
-          [label]="labelFor(type)"
-          [sectionLabel]="sectionLabel(type)"
-          [state]="readinessState(type)"
-          [summary]="readinessSummary(type)"
-          [helpText]="catalogProviderHelp(type)"
-          [form]="formFor(type)"
-          [hasStoredApiKey]="hasStoredApiKey(type)"
-          [enabledInputId]="'setup-enabled-' + type"
-          [showEnabledToggle]="showEnabledToggle(type)"
-          [lastHealthyAt]="lastHealthyAt(type)"
-          [lastErrorAt]="lastErrorAt(type)"
-          [errorMessage]="integrations()[type]?.lastErrorMessage ?? null"
-          [primaryActionLabel]="isSaveAndTesting(type) ? 'Saving & testing...' : 'Save & Test'"
-          [primaryDisabled]="isWorking(type)"
-          [secondaryActionLabel]="isSaving(type) ? 'Saving...' : 'Save only'"
-          [secondaryDisabled]="isWorking(type)"
-          [actionHint]="actionHint(type)"
-          [messages]="messagesFor(type)"
-          submitAction="secondary"
-          (primaryAction)="saveAndTestIntegration(type)"
-          (secondaryAction)="saveIntegration(type)"
-        >
-          @if (catalogProvider() === type) {
-            <button
-              panel-actions
-              pButton
-              type="button"
-              text
-              [disabled]="resettingCatalogProvider() || isWorking(type)"
-              (click)="resetCatalogProviderChoice()"
-            >
-              {{ resettingCatalogProvider() ? 'Resetting...' : 'Reset catalog setup' }}
-            </button>
-          }
-        </app-integration-repair-panel>
-      }
-    </section>
+    @if (isSetupComplete()) {
+      <section
+        class="setup-complete-panel app-state-block"
+        data-testid="setup-complete-panel"
+        role="status"
+      >
+        <p class="eyebrow">Setup complete</p>
+        <h2>Stasharr is ready to open</h2>
+        <p class="state-copy app-state-copy">{{ setupCompleteSummary() }}</p>
+        <p class="state-copy app-state-copy">{{ indexingGuidance() }}</p>
 
-    <section class="cards">
-      @for (type of requiredServiceTypes; track type) {
-        <app-integration-repair-panel
-          class="card"
-          [label]="labelFor(type)"
-          [sectionLabel]="sectionLabel(type)"
-          [state]="readinessState(type)"
-          [summary]="readinessSummary(type)"
-          [form]="formFor(type)"
-          [hasStoredApiKey]="hasStoredApiKey(type)"
-          [enabledInputId]="'setup-enabled-' + type"
-          [showEnabledToggle]="showEnabledToggle(type)"
-          [lastHealthyAt]="lastHealthyAt(type)"
-          [lastErrorAt]="lastErrorAt(type)"
-          [errorMessage]="integrations()[type]?.lastErrorMessage ?? null"
-          [primaryActionLabel]="isSaveAndTesting(type) ? 'Saving & testing...' : 'Save & Test'"
-          [primaryDisabled]="isWorking(type)"
-          [secondaryActionLabel]="isSaving(type) ? 'Saving...' : 'Save only'"
-          [secondaryDisabled]="isWorking(type)"
-          [actionHint]="actionHint(type)"
-          [messages]="messagesFor(type)"
-          submitAction="secondary"
-          (primaryAction)="saveAndTestIntegration(type)"
-          (secondaryAction)="saveIntegration(type)"
-        />
-      }
-    </section>
+        <div class="complete-actions app-action-row">
+          <a class="primary-link" [routerLink]="['/home']">Go to Home</a>
+          <a class="secondary-link" [routerLink]="['/settings/indexing']">Open indexing settings</a>
+          <a class="secondary-link" [routerLink]="['/scenes']">Browse Scenes</a>
+        </div>
+      </section>
+    } @else {
+      <section class="cards">
+        @for (type of visibleCatalogProviderTypes(); track type) {
+          <app-integration-repair-panel
+            class="card"
+            [label]="labelFor(type)"
+            [sectionLabel]="sectionLabel(type)"
+            [state]="readinessState(type)"
+            [summary]="readinessSummary(type)"
+            [helpText]="catalogProviderHelp(type)"
+            [form]="formFor(type)"
+            [hasStoredApiKey]="hasStoredApiKey(type)"
+            [enabledInputId]="'setup-enabled-' + type"
+            [showEnabledToggle]="showEnabledToggle(type)"
+            [lastHealthyAt]="lastHealthyAt(type)"
+            [lastErrorAt]="lastErrorAt(type)"
+            [errorMessage]="integrations()[type]?.lastErrorMessage ?? null"
+            [primaryActionLabel]="isSaveAndTesting(type) ? 'Saving & testing...' : 'Save & Test'"
+            [primaryDisabled]="isWorking(type)"
+            [secondaryActionLabel]="isSaving(type) ? 'Saving...' : 'Save only'"
+            [secondaryDisabled]="isWorking(type)"
+            [actionHint]="actionHint(type)"
+            [messages]="messagesFor(type)"
+            submitAction="secondary"
+            (primaryAction)="saveAndTestIntegration(type)"
+            (secondaryAction)="saveIntegration(type)"
+          >
+            @if (catalogProvider() === type) {
+              <button
+                panel-actions
+                pButton
+                type="button"
+                text
+                [disabled]="resettingCatalogProvider() || isWorking(type)"
+                (click)="resetCatalogProviderChoice()"
+              >
+                {{ resettingCatalogProvider() ? 'Resetting...' : 'Reset catalog setup' }}
+              </button>
+            }
+          </app-integration-repair-panel>
+        }
+      </section>
+
+      <section class="cards">
+        @for (type of requiredServiceTypes; track type) {
+          <app-integration-repair-panel
+            class="card"
+            [label]="labelFor(type)"
+            [sectionLabel]="sectionLabel(type)"
+            [state]="readinessState(type)"
+            [summary]="readinessSummary(type)"
+            [form]="formFor(type)"
+            [hasStoredApiKey]="hasStoredApiKey(type)"
+            [enabledInputId]="'setup-enabled-' + type"
+            [showEnabledToggle]="showEnabledToggle(type)"
+            [lastHealthyAt]="lastHealthyAt(type)"
+            [lastErrorAt]="lastErrorAt(type)"
+            [errorMessage]="integrations()[type]?.lastErrorMessage ?? null"
+            [primaryActionLabel]="isSaveAndTesting(type) ? 'Saving & testing...' : 'Save & Test'"
+            [primaryDisabled]="isWorking(type)"
+            [secondaryActionLabel]="isSaving(type) ? 'Saving...' : 'Save only'"
+            [secondaryDisabled]="isWorking(type)"
+            [actionHint]="actionHint(type)"
+            [messages]="messagesFor(type)"
+            submitAction="secondary"
+            (primaryAction)="saveAndTestIntegration(type)"
+            (secondaryAction)="saveIntegration(type)"
+          />
+        }
+      </section>
+    }
   }
 </main>

--- a/apps/sp-web/src/app/features/setup/setup-page.component.scss
+++ b/apps/sp-web/src/app/features/setup/setup-page.component.scss
@@ -35,8 +35,67 @@ p {
   border: 1px solid var(--border-subtle);
   border-radius: 16px;
   padding: 1rem;
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--surface-2) 88%, transparent), var(--surface-1));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-2) 88%, transparent),
+    var(--surface-1)
+  );
+}
+
+.handoff-panel,
+.setup-complete-panel {
+  margin-top: 1rem;
+}
+
+.handoff-panel {
+  --app-alert-radius: 8px;
+}
+
+.handoff-copy p:last-child {
+  color: var(--text-muted);
+  max-width: 68ch;
+}
+
+.setup-complete-panel {
+  --app-state-radius: 8px;
+  --app-state-border: 1px solid var(--tone-success-border);
+  --app-state-bg: var(--tone-success-background);
+}
+
+.state-copy {
+  color: color-mix(in srgb, var(--text-muted) 92%, var(--text-primary));
+}
+
+.complete-actions {
+  margin-top: 0.2rem;
+}
+
+.primary-link,
+.secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.78rem;
+  border-radius: 6px;
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  color: var(--button-text);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.primary-link {
+  border-color: var(--tone-success-border);
+  background: color-mix(in srgb, var(--success-bg) 82%, var(--surface-elevated));
+  color: var(--tone-success-text);
+}
+
+.primary-link:focus-visible,
+.secondary-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .overview-head,

--- a/apps/sp-web/src/app/features/setup/setup-page.component.spec.ts
+++ b/apps/sp-web/src/app/features/setup/setup-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Router, provideRouter } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { of } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { IntegrationsService } from '../../core/api/integrations.service';
@@ -17,18 +17,17 @@ function buildIntegration(
     type: overrides.type,
     enabled: overrides.enabled ?? true,
     status,
-    name: 'name' in overrides ? overrides.name ?? null : null,
-    baseUrl: 'baseUrl' in overrides ? overrides.baseUrl ?? null : 'http://service.local',
+    name: 'name' in overrides ? (overrides.name ?? null) : null,
+    baseUrl: 'baseUrl' in overrides ? (overrides.baseUrl ?? null) : 'http://service.local',
     hasApiKey: overrides.hasApiKey ?? true,
     lastHealthyAt:
       'lastHealthyAt' in overrides
-        ? overrides.lastHealthyAt ?? null
+        ? (overrides.lastHealthyAt ?? null)
         : status === 'CONFIGURED'
           ? '2026-04-01T00:00:00.000Z'
           : null,
-    lastErrorAt: 'lastErrorAt' in overrides ? overrides.lastErrorAt ?? null : null,
-    lastErrorMessage:
-      'lastErrorMessage' in overrides ? overrides.lastErrorMessage ?? null : null,
+    lastErrorAt: 'lastErrorAt' in overrides ? (overrides.lastErrorAt ?? null) : null,
+    lastErrorMessage: 'lastErrorMessage' in overrides ? (overrides.lastErrorMessage ?? null) : null,
   };
 }
 
@@ -41,7 +40,12 @@ describe('SetupPageComponent', () => {
     TestBed.resetTestingModule();
   });
 
-  async function renderPage(status: SetupStatusResponse, integrations: IntegrationResponse[]) {
+  async function renderPage(
+    status: SetupStatusResponse,
+    integrations: IntegrationResponse[],
+    options: { queryParams?: Record<string, string> } = {},
+  ) {
+    const queryParamMap = convertToParamMap(options.queryParams ?? {});
     const setupService = {
       getStatus: vi.fn().mockReturnValue(of(status)),
     };
@@ -72,6 +76,14 @@ describe('SetupPageComponent', () => {
         {
           provide: AppNotificationsService,
           useValue: notifications,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap,
+            },
+          },
         },
       ],
     }).compileComponents();
@@ -173,6 +185,63 @@ describe('SetupPageComponent', () => {
     );
     expect(textContent(stashCard)).toContain('Save & Test');
     expect(textContent(stashCard)).toContain('Save only');
+  });
+
+  it('shows a bootstrap handoff when the admin account just sent the user to setup', async () => {
+    const { fixture } = await renderPage(
+      {
+        setupComplete: false,
+        required: { stash: false, catalog: false, whisparr: false },
+        catalogProvider: null,
+      },
+      [
+        buildIntegration({ type: 'STASH', status: 'NOT_CONFIGURED', baseUrl: null }),
+        buildIntegration({ type: 'WHISPARR', status: 'NOT_CONFIGURED', baseUrl: null }),
+        buildIntegration({ type: 'STASHDB', status: 'NOT_CONFIGURED', baseUrl: null }),
+        buildIntegration({ type: 'FANSDB', status: 'NOT_CONFIGURED', baseUrl: null }),
+      ],
+      {
+        queryParams: { from: 'bootstrap' },
+      },
+    );
+
+    const handoff = fixture.nativeElement.querySelector(
+      '[data-testid="setup-bootstrap-handoff"]',
+    ) as HTMLElement | null;
+
+    expect(textContent(handoff)).toContain('Admin account ready');
+    expect(textContent(handoff)).toContain('Connect the required integrations next');
+    expect(textContent(handoff)).toContain('catalog provider');
+  });
+
+  it('renders a setup-complete milestone with app and indexing CTAs', async () => {
+    const { fixture } = await renderPage(
+      {
+        setupComplete: true,
+        required: { stash: true, catalog: true, whisparr: true },
+        catalogProvider: 'STASHDB',
+      },
+      [
+        buildIntegration({ type: 'STASH' }),
+        buildIntegration({ type: 'WHISPARR' }),
+        buildIntegration({ type: 'STASHDB' }),
+      ],
+    );
+
+    const panel = fixture.nativeElement.querySelector(
+      '[data-testid="setup-complete-panel"]',
+    ) as HTMLElement | null;
+    const links = Array.from(panel?.querySelectorAll('a') ?? []) as HTMLAnchorElement[];
+
+    expect(textContent(panel)).toContain('Setup complete');
+    expect(textContent(panel)).toContain('Stasharr is ready to open');
+    expect(textContent(panel)).toContain('Library, Acquisition, and status badges');
+    expect(textContent(panel)).toContain('Sync All');
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      '/home',
+      '/settings/indexing',
+      '/scenes',
+    ]);
   });
 
   it('renders Saved, Test Failed, and Ready states clearly in the checklist and cards', async () => {
@@ -356,7 +425,9 @@ describe('SetupPageComponent', () => {
       apiKey: 'token-123',
     });
     expect(notifications.success).toHaveBeenCalledWith('Whisparr is ready.');
-    expect(textContent(cardByTitle(fixture, 'Whisparr'))).toContain('Whisparr is ready.');
-    expect(navigateByUrl).toHaveBeenCalledWith('/scenes');
+    expect(
+      textContent(fixture.nativeElement.querySelector('[data-testid="setup-complete-panel"]')),
+    ).toContain('Stasharr is ready to open');
+    expect(navigateByUrl).not.toHaveBeenCalled();
   });
 });

--- a/apps/sp-web/src/app/features/setup/setup-page.component.ts
+++ b/apps/sp-web/src/app/features/setup/setup-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Observable, finalize, forkJoin, map, switchMap } from 'rxjs';
 import { ButtonDirective } from 'primeng/button';
 import { Message } from 'primeng/message';
@@ -36,15 +36,14 @@ import {
   mapIntegrationsByType,
   patchActionState,
 } from '../../shared/integration-repair/integration-repair.utils';
+import {
+  initialIndexingGuidance,
+  setupCompleteSummary,
+} from '../../shared/readiness/first-run-readiness.utils';
 
 @Component({
   selector: 'app-setup-page',
-  imports: [
-    Message,
-    ProgressSpinner,
-    ButtonDirective,
-    IntegrationRepairPanelComponent,
-  ],
+  imports: [Message, ProgressSpinner, ButtonDirective, RouterLink, IntegrationRepairPanelComponent],
   templateUrl: './setup-page.component.html',
   styleUrl: './setup-page.component.scss',
 })
@@ -52,12 +51,13 @@ export class SetupPageComponent implements OnInit {
   private readonly setupService = inject(SetupService);
   private readonly integrationsService = inject(IntegrationsService);
   private readonly notifications = inject(AppNotificationsService);
-  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   protected readonly loading = signal(true);
   protected readonly loadError = signal<string | null>(null);
   protected readonly status = signal<SetupStatusResponse | null>(null);
   protected readonly resettingCatalogProvider = signal(false);
+  protected readonly bootstrapHandoff = signal(false);
 
   private readonly allIntegrationTypes: IntegrationType[] = [
     'STASH',
@@ -84,17 +84,14 @@ export class SetupPageComponent implements OnInit {
     createEmptyIntegrationsRecord(),
   );
 
-  protected readonly saveState = signal<Record<IntegrationType, IntegrationActionState>>(
-    createActionStateRecord(),
-  );
+  protected readonly saveState =
+    signal<Record<IntegrationType, IntegrationActionState>>(createActionStateRecord());
 
-  protected readonly testState = signal<Record<IntegrationType, IntegrationActionState>>(
-    createActionStateRecord(),
-  );
+  protected readonly testState =
+    signal<Record<IntegrationType, IntegrationActionState>>(createActionStateRecord());
 
-  protected readonly saveAndTestState = signal<Record<IntegrationType, IntegrationActionState>>(
-    createActionStateRecord(),
-  );
+  protected readonly saveAndTestState =
+    signal<Record<IntegrationType, IntegrationActionState>>(createActionStateRecord());
 
   protected readonly isSetupComplete = computed(() => this.status()?.setupComplete ?? false);
   protected readonly checklistItems = computed<SetupChecklistItem[]>(() => [
@@ -110,6 +107,7 @@ export class SetupPageComponent implements OnInit {
   );
 
   ngOnInit(): void {
+    this.bootstrapHandoff.set(this.route.snapshot.queryParamMap.get('from') === 'bootstrap');
     this.loadSetupData();
   }
 
@@ -162,6 +160,17 @@ export class SetupPageComponent implements OnInit {
     return `${this.labelFor(catalogProvider)} is locked in as the catalog provider. Finish the remaining required services to complete setup.`;
   }
 
+  protected setupCompleteSummary(): string {
+    const catalogProvider = this.catalogProvider();
+    return setupCompleteSummary(
+      catalogProvider ? this.labelFor(catalogProvider) : 'The catalog provider',
+    );
+  }
+
+  protected indexingGuidance(): string {
+    return initialIndexingGuidance();
+  }
+
   protected catalogProviderHelp(type: IntegrationType): string | null {
     if (!this.isCatalogProvider(type)) {
       return null;
@@ -184,7 +193,9 @@ export class SetupPageComponent implements OnInit {
 
   protected sectionLabel(type: IntegrationType): string {
     if (this.isCatalogProvider(type)) {
-      return this.catalogProvider() === type ? 'Chosen catalog provider' : 'Catalog provider option';
+      return this.catalogProvider() === type
+        ? 'Chosen catalog provider'
+        : 'Catalog provider option';
     }
 
     return 'Required service';
@@ -321,10 +332,6 @@ export class SetupPageComponent implements OnInit {
             success: message,
             error: null,
           });
-
-          if (status.setupComplete) {
-            void this.router.navigateByUrl('/scenes');
-          }
         },
         error: (error: unknown) => {
           const message = describeMutationError(error, `Failed to save ${this.labelFor(type)}.`);
@@ -369,10 +376,6 @@ export class SetupPageComponent implements OnInit {
               success: message,
               error: null,
             });
-
-            if (status.setupComplete) {
-              void this.router.navigateByUrl('/scenes');
-            }
             return;
           }
 
@@ -426,10 +429,6 @@ export class SetupPageComponent implements OnInit {
               success: message,
               error: null,
             });
-
-            if (status.setupComplete) {
-              void this.router.navigateByUrl('/scenes');
-            }
             return;
           }
 
@@ -473,9 +472,7 @@ export class SetupPageComponent implements OnInit {
           this.notifications.info('Catalog setup was reset');
         },
         error: (error: unknown) => {
-          this.notifications.error(
-            describeMutationError(error, 'Failed to reset catalog setup.'),
-          );
+          this.notifications.error(describeMutationError(error, 'Failed to reset catalog setup.'));
         },
       });
   }
@@ -496,10 +493,6 @@ export class SetupPageComponent implements OnInit {
       .subscribe({
         next: (response) => {
           this.syncSetupState(response.status, response.integrations);
-
-          if (response.status.setupComplete) {
-            void this.router.navigateByUrl('/scenes');
-          }
         },
         error: () => {
           this.loadError.set('Failed to load setup data from the API.');
@@ -633,10 +626,7 @@ export class SetupPageComponent implements OnInit {
     });
   }
 
-  private syncSetupState(
-    status: SetupStatusResponse,
-    integrations: IntegrationResponse[],
-  ): void {
+  private syncSetupState(status: SetupStatusResponse, integrations: IntegrationResponse[]): void {
     this.status.set(status);
     this.applyIntegrations(integrations);
   }
@@ -650,10 +640,7 @@ export class SetupPageComponent implements OnInit {
     return this.integrations()[catalogProvider]?.status === 'ERROR';
   }
 
-  private describeSaveSuccess(
-    type: IntegrationType,
-    integration: IntegrationResponse,
-  ): string {
+  private describeSaveSuccess(type: IntegrationType, integration: IntegrationResponse): string {
     if (integration.status === 'ERROR') {
       return `${this.labelFor(type)} settings saved. Repair the connection details and run the test again.`;
     }

--- a/apps/sp-web/src/app/pages/acquisition/acquisition-page.component.html
+++ b/apps/sp-web/src/app/pages/acquisition/acquisition-page.component.html
@@ -2,12 +2,18 @@
   <header class="page-head app-page-header">
     <div class="page-copy app-page-header__copy">
       <h1>Acquisition</h1>
-      <p class="app-page-lede">Track requested scenes through Whisparr and into your Stash library.</p>
+      <p class="app-page-lede">
+        Track requested scenes through Whisparr and into your Stash library.
+      </p>
     </div>
   </header>
 
   @if (pageAlert(); as alert) {
-    <section class="page-alert app-page-alert" data-testid="acquisition-degraded-state" role="status">
+    <section
+      class="page-alert app-page-alert"
+      data-testid="acquisition-degraded-state"
+      role="status"
+    >
       <div class="page-alert-copy app-page-alert__copy">
         <p class="eyebrow app-page-eyebrow">{{ alert.eyebrow }}</p>
         <h2>{{ alert.title }}</h2>
@@ -15,7 +21,10 @@
       </div>
 
       <div class="page-alert-actions app-action-row">
-        <a class="primary-link small" [routerLink]="['/settings']">Open Settings</a>
+        <a class="primary-link small" [routerLink]="['/settings/integrations']">
+          Repair integrations
+        </a>
+        <a class="secondary-link small" [routerLink]="['/settings/indexing']">Open Indexing</a>
         <a class="secondary-link small" [routerLink]="['/scenes']">Open Scenes</a>
       </div>
     </section>
@@ -54,10 +63,16 @@
     </section>
 
     @if (!hasItems()) {
-      <section class="state-shell empty-shell app-state-block" data-testid="acquisition-empty-state">
+      <section
+        class="state-shell empty-shell app-state-block"
+        data-testid="acquisition-empty-state"
+      >
         <p class="eyebrow app-page-eyebrow">Pipeline Quiet</p>
         <h2>{{ emptyStateTitle() }}</h2>
         <p class="state-copy app-state-copy">{{ emptyStateMessage() }}</p>
+        @if (selectedLifecycle() === 'ANY') {
+          <p class="state-copy app-state-copy">{{ indexingGuidance() }}</p>
+        }
 
         <div class="state-actions app-action-row">
           @if (selectedLifecycle() !== 'ANY') {
@@ -66,7 +81,13 @@
             </button>
           }
           <a class="primary-link" [routerLink]="['/scenes']">Open Scenes</a>
+          <a class="secondary-link" [routerLink]="['/settings/indexing']">Open Indexing</a>
           <a class="secondary-link" [routerLink]="['/library']">Open Library</a>
+          @if (pageAlert()) {
+            <a class="secondary-link" [routerLink]="['/settings/integrations']">
+              Repair integrations
+            </a>
+          }
         </div>
       </section>
     } @else {

--- a/apps/sp-web/src/app/pages/acquisition/acquisition-page.component.spec.ts
+++ b/apps/sp-web/src/app/pages/acquisition/acquisition-page.component.spec.ts
@@ -338,8 +338,11 @@ describe('AcquisitionPageComponent', () => {
     expect(degradedState?.textContent).toContain(
       'Queue state, failures, and request progression may be stale',
     );
-    expect(emptyState?.textContent).toContain('Nothing is moving through acquisition right now');
+    expect(degradedState?.querySelector('a[href*="/settings/integrations"]')).toBeTruthy();
+    expect(emptyState?.textContent).toContain('No acquisition activity is indexed yet');
+    expect(emptyState?.textContent).toContain('run Sync All');
     expect(emptyState?.textContent).toContain('Open Scenes');
+    expect(emptyState?.textContent).toContain('Open Indexing');
     expect(emptyState?.textContent).toContain('Open Library');
   });
 

--- a/apps/sp-web/src/app/pages/acquisition/acquisition-page.component.ts
+++ b/apps/sp-web/src/app/pages/acquisition/acquisition-page.component.ts
@@ -21,10 +21,13 @@ import {
   AcquisitionSceneItem,
 } from '../../core/api/acquisition.types';
 import { RuntimeHealthService } from '../../core/api/runtime-health.service';
-import { summarizeRuntimeDegradedState } from '../../core/api/runtime-health.types';
 import { SetupStatusStore } from '../../core/api/setup-status.store';
-import { summarizeDegradedSetupState } from '../../core/api/setup.types';
 import { SceneStatusBadgeComponent } from '../../shared/scene-status-badge/scene-status-badge.component';
+import {
+  buildReadinessPageAlert,
+  firstUseEmptyStateCopy,
+  initialIndexingGuidance,
+} from '../../shared/readiness/first-run-readiness.utils';
 
 type AcquisitionSectionTone = 'attention' | 'pending' | 'active' | 'passive' | 'overview';
 
@@ -183,28 +186,10 @@ export class AcquisitionPageComponent implements OnInit, AfterViewInit, OnDestro
     ).filter((section) => section.items.length > 0);
   });
   protected readonly pageAlert = computed<AcquisitionPageAlert | null>(() => {
-    const setupState = summarizeDegradedSetupState(this.setupStatusStore.status());
-    if (setupState) {
-      const alert = this.buildDegradedAlert(
-        setupState.services.map((service) => service.key),
-        'setup',
-      );
-      if (alert) {
-        return alert;
-      }
-    }
-
-    const runtimeState = summarizeRuntimeDegradedState(
+    return buildReadinessPageAlert(
+      'acquisition',
+      this.setupStatusStore.status(),
       this.runtimeHealth(),
-      this.setupStatusStore.status()?.catalogProvider ?? null,
-    );
-    if (!runtimeState) {
-      return null;
-    }
-
-    return this.buildDegradedAlert(
-      runtimeState.services.map((service) => service.key),
-      'runtime',
     );
   });
 
@@ -379,11 +364,15 @@ export class AcquisitionPageComponent implements OnInit, AfterViewInit, OnDestro
         return 'No queued requests are waiting to start';
       case 'ANY':
       default:
-        return 'Nothing is moving through acquisition right now';
+        return firstUseEmptyStateCopy('acquisition').title;
     }
   }
 
   protected emptyStateMessage(): string {
+    if (this.selectedLifecycle() === 'ANY' && this.pageAlert()) {
+      return 'Acquisition may look empty because Whisparr or Stash is degraded. Repair integrations, then run Sync All from Indexing & Sync if tracked requests still do not appear.';
+    }
+
     switch (this.selectedLifecycle()) {
       case 'FAILED':
         return 'There is nothing to recover in Whisparr at the moment. Switch back to the full pipeline or request something new from Scenes.';
@@ -395,8 +384,12 @@ export class AcquisitionPageComponent implements OnInit, AfterViewInit, OnDestro
         return 'Whisparr is not holding any queued requests that have not started yet.';
       case 'ANY':
       default:
-        return 'Requests begin in Scenes. Once Whisparr downloads and Stash imports them, they leave this page and continue in Library.';
+        return firstUseEmptyStateCopy('acquisition').message;
     }
+  }
+
+  protected indexingGuidance(): string {
+    return initialIndexingGuidance();
   }
 
   protected currentRouteUrl(): string {
@@ -478,43 +471,6 @@ export class AcquisitionPageComponent implements OnInit, AfterViewInit, OnDestro
 
   private humanizeStatus(value: string): string {
     return value.trim().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').toLowerCase();
-  }
-
-  private buildDegradedAlert(
-    services: string[],
-    source: 'setup' | 'runtime',
-  ): AcquisitionPageAlert | null {
-    const whisparrImpacted = services.includes('WHISPARR');
-    const stashImpacted = services.includes('STASH');
-
-    if (!whisparrImpacted && !stashImpacted) {
-      return null;
-    }
-
-    if (whisparrImpacted && stashImpacted) {
-      return {
-        eyebrow: source === 'setup' ? 'Repair Required' : 'Runtime Outage',
-        title: 'Acquisition tracking is degraded',
-        message:
-          'Whisparr and Stash are both affecting this page. Request progress, failure states, and import visibility may be incomplete or stale until both recover.',
-      };
-    }
-
-    if (whisparrImpacted) {
-      return {
-        eyebrow: source === 'setup' ? 'Repair Required' : 'Runtime Outage',
-        title: 'Whisparr needs attention',
-        message:
-          'Acquisition progress on this page depends on Whisparr. Queue state, failures, and request progression may be stale until it is healthy again.',
-      };
-    }
-
-    return {
-      eyebrow: source === 'setup' ? 'Repair Required' : 'Runtime Outage',
-      title: 'Stash import visibility is degraded',
-      message:
-        'Downloaded scenes may take longer to appear as imported while Stash is unhealthy. Check Settings if import handoffs look stuck.',
-    };
   }
 
   private loadNextPage(): void {

--- a/apps/sp-web/src/app/pages/home/home-page.component.html
+++ b/apps/sp-web/src/app/pages/home/home-page.component.html
@@ -34,6 +34,21 @@
     </div>
   </section>
 
+  @if (pageAlert(); as alert) {
+    <section class="home-alert app-page-alert" data-testid="home-readiness-alert" role="status">
+      <div class="app-page-alert__copy">
+        <p class="eyebrow">{{ alert.eyebrow }}</p>
+        <h2>{{ alert.title }}</h2>
+        <p>{{ alert.message }}</p>
+      </div>
+
+      <div class="home-alert-actions app-action-row">
+        <a class="hero-link" [routerLink]="['/settings/integrations']">Repair integrations</a>
+        <a class="hero-link secondary" [routerLink]="['/settings/indexing']">Open indexing</a>
+      </div>
+    </section>
+  }
+
   @if (loading()) {
     <div class="home-state loading app-state-block" role="status" aria-live="polite">
       <p-progressspinner
@@ -511,15 +526,16 @@
       </section>
     } @else if (isPageEmptyState()) {
       <section class="home-state empty-state app-state-block">
-        <h2>No enabled rails are matching scenes yet</h2>
-        <p>
-          Try favoriting more performers or studios, or add a custom rail with broader tags,
-          studios, or favorites filters.
-        </p>
+        <h2>{{ emptyStateTitle() }}</h2>
+        <p>{{ emptyStateMessage() }}</p>
+        <p>{{ indexingGuidance() }}</p>
         <div class="empty-links app-action-row">
-          <button type="button" class="hero-link" (click)="openEditor()">Customize Home</button>
-          <a class="hero-link secondary" [routerLink]="['/scenes']">Browse Scenes</a>
+          <a class="hero-link" [routerLink]="['/scenes']">Browse Scenes</a>
+          <a class="hero-link secondary" [routerLink]="['/settings/indexing']">Open Indexing</a>
           <a class="hero-link secondary" [routerLink]="['/library']">Browse Library</a>
+          <button type="button" class="hero-link secondary" (click)="openEditor()">
+            Customize Home
+          </button>
         </div>
       </section>
     } @else {

--- a/apps/sp-web/src/app/pages/home/home-page.component.scss
+++ b/apps/sp-web/src/app/pages/home/home-page.component.scss
@@ -4,7 +4,11 @@
   color: var(--text-primary);
   font-family: var(--app-font-family);
   background:
-    radial-gradient(circle at top right, color-mix(in srgb, var(--focus-ring) 22%, transparent), transparent 32%),
+    radial-gradient(
+      circle at top right,
+      color-mix(in srgb, var(--focus-ring) 22%, transparent),
+      transparent 32%
+    ),
     linear-gradient(
       180deg,
       color-mix(in srgb, var(--app-bg) 84%, var(--surface-raised)) 0%,
@@ -140,6 +144,20 @@ p {
   margin-top: 1rem;
   --app-state-radius: 18px;
   --app-state-padding: 1rem;
+}
+
+.home-alert {
+  margin-top: 1rem;
+  --app-alert-radius: 8px;
+}
+
+.home-alert p:last-child {
+  color: var(--text-muted);
+  max-width: 70ch;
+}
+
+.home-alert-actions {
+  align-self: center;
 }
 
 .home-state.loading {

--- a/apps/sp-web/src/app/pages/home/home-page.component.spec.ts
+++ b/apps/sp-web/src/app/pages/home/home-page.component.spec.ts
@@ -1,3 +1,4 @@
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { of } from 'rxjs';
@@ -5,6 +6,10 @@ import { DiscoverService } from '../../core/api/discover.service';
 import { SceneExplorerItem, ScenesFeedResponse } from '../../core/api/discover.types';
 import { HomeService } from '../../core/api/home.service';
 import { HomeRailConfig, HomeRailContentResponse, HomeRailItem } from '../../core/api/home.types';
+import { RuntimeHealthService } from '../../core/api/runtime-health.service';
+import { RuntimeHealthResponse } from '../../core/api/runtime-health.types';
+import { SetupStatusStore } from '../../core/api/setup-status.store';
+import { SetupStatusResponse } from '../../core/api/setup.types';
 import { AppNotificationsService } from '../../core/notifications/app-notifications.service';
 import { HomePageComponent } from './home-page.component';
 
@@ -61,12 +66,71 @@ function buildRailItem(overrides: Partial<HomeRailItem> = {}): HomeRailItem {
   };
 }
 
+function buildSetupStatus(
+  overrides: Partial<Omit<SetupStatusResponse, 'required'>> & {
+    required?: Partial<SetupStatusResponse['required']>;
+  } = {},
+): SetupStatusResponse {
+  return {
+    setupComplete: overrides.setupComplete ?? true,
+    required: {
+      stash: true,
+      catalog: true,
+      whisparr: true,
+      ...(overrides.required ?? {}),
+    },
+    catalogProvider: overrides.catalogProvider ?? 'STASHDB',
+  };
+}
+
+const HEALTHY_RUNTIME_HEALTH: RuntimeHealthResponse = {
+  degraded: false,
+  failureThreshold: 3,
+  services: {
+    catalog: {
+      service: 'CATALOG',
+      status: 'HEALTHY',
+      degraded: false,
+      consecutiveFailures: 0,
+      lastHealthyAt: '2026-04-02T00:00:00.000Z',
+      lastFailureAt: null,
+      lastErrorMessage: null,
+      degradedAt: null,
+    },
+    stash: {
+      service: 'STASH',
+      status: 'HEALTHY',
+      degraded: false,
+      consecutiveFailures: 0,
+      lastHealthyAt: '2026-04-02T00:00:00.000Z',
+      lastFailureAt: null,
+      lastErrorMessage: null,
+      degradedAt: null,
+    },
+    whisparr: {
+      service: 'WHISPARR',
+      status: 'HEALTHY',
+      degraded: false,
+      consecutiveFailures: 0,
+      lastHealthyAt: '2026-04-02T00:00:00.000Z',
+      lastFailureAt: null,
+      lastErrorMessage: null,
+      degradedAt: null,
+    },
+  },
+};
+
 describe('HomePageComponent', () => {
   afterEach(() => {
     TestBed.resetTestingModule();
   });
 
-  async function renderPage() {
+  async function renderPage(options?: {
+    discoverFeed?: ScenesFeedResponse;
+    homeRailItemsById?: Record<string, HomeRailContentResponse>;
+    runtimeHealth?: RuntimeHealthResponse;
+    setupStatus?: SetupStatusResponse;
+  }) {
     const rails: HomeRailConfig[] = [
       {
         id: 'rail-stashdb',
@@ -121,15 +185,16 @@ describe('HomePageComponent', () => {
       },
     ];
 
-    const homeRailItemsById: Record<string, HomeRailContentResponse> = {
-      'rail-stash': {
-        items: [buildRailItem()],
-        message: null,
-      },
-    };
+    const homeRailItemsById: Record<string, HomeRailContentResponse> =
+      options?.homeRailItemsById ?? {
+        'rail-stash': {
+          items: [buildRailItem()],
+          message: null,
+        },
+      };
 
     const discoverService = {
-      getScenesFeed: vi.fn().mockReturnValue(of(buildDiscoverFeed())),
+      getScenesFeed: vi.fn().mockReturnValue(of(options?.discoverFeed ?? buildDiscoverFeed())),
       searchSceneTags: vi.fn().mockReturnValue(of([])),
       searchPerformerStudios: vi.fn().mockReturnValue(of([])),
       getSceneRequestOptions: vi.fn().mockReturnValue(of(null)),
@@ -145,6 +210,14 @@ describe('HomePageComponent', () => {
       updateRail: vi.fn(),
       deleteRail: vi.fn(),
     };
+    const runtimeHealthService = {
+      ensureStarted: vi.fn(),
+      status: signal(options?.runtimeHealth ?? HEALTHY_RUNTIME_HEALTH).asReadonly(),
+    };
+    const setupStatusStore = {
+      status: signal(options?.setupStatus ?? buildSetupStatus()),
+      sync: vi.fn(),
+    };
 
     await TestBed.configureTestingModule({
       imports: [HomePageComponent],
@@ -157,6 +230,14 @@ describe('HomePageComponent', () => {
         {
           provide: HomeService,
           useValue: homeService,
+        },
+        {
+          provide: RuntimeHealthService,
+          useValue: runtimeHealthService,
+        },
+        {
+          provide: SetupStatusStore,
+          useValue: setupStatusStore,
         },
         {
           provide: AppNotificationsService,
@@ -174,7 +255,7 @@ describe('HomePageComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    return { fixture, discoverService };
+    return { fixture, discoverService, runtimeHealthService };
   }
 
   function railSectionByTitle(
@@ -194,7 +275,7 @@ describe('HomePageComponent', () => {
   }
 
   it('routes STASHDB rails to /scenes and STASH rails to /library', async () => {
-    const { fixture, discoverService } = await renderPage();
+    const { fixture, discoverService, runtimeHealthService } = await renderPage();
 
     expect(discoverService.getScenesFeed).toHaveBeenCalledWith(
       1,
@@ -228,6 +309,7 @@ describe('HomePageComponent', () => {
     expect(libraryLink?.getAttribute('href')).toContain('favoriteTagsOnly=1');
     expect(libraryLink?.getAttribute('href')).toContain('tags=tag-2');
     expect(libraryLink?.getAttribute('href')).toContain('studios=studio-2');
+    expect(runtimeHealthService.ensureStarted).toHaveBeenCalledTimes(1);
   });
 
   it('renders Home rails through the shared scene card and preserves request routing', async () => {
@@ -236,8 +318,12 @@ describe('HomePageComponent', () => {
     const cards = fixture.nativeElement.querySelectorAll('app-scene-card');
     const discoverySection = railSectionByTitle(fixture, 'Discovery Rail');
     const librarySection = railSectionByTitle(fixture, 'Library Rail');
-    const requestButton = discoverySection.querySelector('.request-cta') as HTMLButtonElement | null;
-    const libraryLink = librarySection.querySelector('.media-link-stretch') as HTMLAnchorElement | null;
+    const requestButton = discoverySection.querySelector(
+      '.request-cta',
+    ) as HTMLButtonElement | null;
+    const libraryLink = librarySection.querySelector(
+      '.media-link-stretch',
+    ) as HTMLAnchorElement | null;
 
     expect(cards).toHaveLength(2);
     expect(libraryLink?.getAttribute('href')).toBe('http://stash.local/scenes/local-scene-1');
@@ -276,5 +362,24 @@ describe('HomePageComponent', () => {
 
     expect(fixture.nativeElement.querySelector('#home-rail-hybrid-favorites')).toBeNull();
     expect(fixture.nativeElement.querySelector('#home-rail-library-availability')).toBeNull();
+  });
+
+  it('guides first-run users when Home rails have no data yet', async () => {
+    const { fixture } = await renderPage({
+      discoverFeed: buildDiscoverFeed([]),
+      homeRailItemsById: {
+        'rail-stash': {
+          items: [],
+          message: null,
+        },
+      },
+    });
+
+    const text = fixture.nativeElement.textContent ?? '';
+
+    expect(text).toContain('Home is waiting for useful scene data');
+    expect(text).toContain('Run the initial indexing sync');
+    expect(text).toContain('Open Indexing');
+    expect(text).toContain('Browse Scenes');
   });
 });

--- a/apps/sp-web/src/app/pages/home/home-page.component.ts
+++ b/apps/sp-web/src/app/pages/home/home-page.component.ts
@@ -5,6 +5,7 @@ import {
   OnInit,
   QueryList,
   ViewChildren,
+  computed,
   inject,
   signal,
 } from '@angular/core';
@@ -49,8 +50,15 @@ import {
   HomeRailViewSummary,
   SaveHomeRailPayload,
 } from '../../core/api/home.types';
+import { RuntimeHealthService } from '../../core/api/runtime-health.service';
+import { SetupStatusStore } from '../../core/api/setup-status.store';
 import { SceneCardComponent } from '../../shared/scene-card/scene-card.component';
 import { SceneRequestModalComponent } from '../../shared/scene-request-modal/scene-request-modal.component';
+import {
+  buildReadinessPageAlert,
+  firstUseEmptyStateCopy,
+  initialIndexingGuidance,
+} from '../../shared/readiness/first-run-readiness.utils';
 
 type HomeRailView = HomeRailConfig & {
   items: HomeRailItem[];
@@ -153,6 +161,8 @@ export class HomePageComponent implements OnInit, OnDestroy {
 
   private readonly discoverService = inject(DiscoverService);
   private readonly homeService = inject(HomeService);
+  private readonly runtimeHealthService = inject(RuntimeHealthService);
+  private readonly setupStatusStore = inject(SetupStatusStore);
   private readonly router = inject(Router);
   private readonly tagSearchTerms = new Subject<string>();
   private readonly studioSearchTerms = new Subject<string>();
@@ -200,6 +210,13 @@ export class HomePageComponent implements OnInit, OnDestroy {
   protected readonly railErrorsById = signal<Record<string, string>>({});
   protected readonly requestModalOpen = signal(false);
   protected readonly requestContext = signal<SceneRequestContext | null>(null);
+  protected readonly pageAlert = computed(() =>
+    buildReadinessPageAlert(
+      'home',
+      this.setupStatusStore.status(),
+      this.runtimeHealthService.status(),
+    ),
+  );
 
   protected readonly sortOptions = HomePageComponent.SORT_OPTIONS;
   protected readonly stashSortOptions = HomePageComponent.STASH_SORT_OPTIONS;
@@ -209,6 +226,7 @@ export class HomePageComponent implements OnInit, OnDestroy {
   protected readonly tagMatchOptions = HomePageComponent.TAG_MATCH_OPTIONS;
 
   ngOnInit(): void {
+    this.runtimeHealthService.ensureStarted();
     this.setupTagSearch();
     this.setupStudioSearch();
     this.loadHome();
@@ -302,6 +320,22 @@ export class HomePageComponent implements OnInit, OnDestroy {
     }
 
     return enabledRails.every((rail) => rail.items.length === 0 && rail.error === null);
+  }
+
+  protected emptyStateTitle(): string {
+    return firstUseEmptyStateCopy('home').title;
+  }
+
+  protected emptyStateMessage(): string {
+    if (this.pageAlert()) {
+      return 'Home rails may be empty because required integrations are degraded. Repair integrations, then refresh Home to reload rail data.';
+    }
+
+    return firstUseEmptyStateCopy('home').message;
+  }
+
+  protected indexingGuidance(): string {
+    return initialIndexingGuidance();
   }
 
   protected openEditor(): void {
@@ -553,9 +587,7 @@ export class HomePageComponent implements OnInit, OnDestroy {
       | 'limit'
     >,
   >(field: K, value: HomeRailFormDraft[K]): void {
-    this.railForm.update((current) =>
-      current ? { ...current, [field]: value } : current,
-    );
+    this.railForm.update((current) => (current ? { ...current, [field]: value } : current));
   }
 
   protected updateRailSource(nextSource: HomeRailSource): void {

--- a/apps/sp-web/src/app/pages/library/library-page.component.html
+++ b/apps/sp-web/src/app/pages/library/library-page.component.html
@@ -15,7 +15,10 @@
       </div>
 
       <div class="page-alert-actions app-action-row">
-        <a class="secondary-link small" [routerLink]="['/settings']">Open Settings</a>
+        <a class="secondary-link small" [routerLink]="['/settings/integrations']">
+          Repair integrations
+        </a>
+        <a class="secondary-link small" [routerLink]="['/settings/indexing']">Open Indexing</a>
         <a class="secondary-link small" [routerLink]="['/acquisition']">Track Imports</a>
       </div>
     </section>
@@ -244,6 +247,9 @@
     <section class="state-shell empty-shell app-state-block" data-testid="library-empty-state">
       <h2>{{ emptyStateTitle() }}</h2>
       <p class="state-copy app-state-copy">{{ emptyStateMessage() }}</p>
+      @if (!hasNarrowingFilters()) {
+        <p class="state-copy app-state-copy">{{ indexingGuidance() }}</p>
+      }
 
       <div class="state-actions app-action-row">
         @if (hasNarrowingFilters()) {
@@ -254,9 +260,12 @@
           <a class="secondary-link" [routerLink]="['/acquisition']">Track Imports</a>
         } @else {
           <a class="primary-link" [routerLink]="['/acquisition']">Track Imports</a>
+          <a class="secondary-link" [routerLink]="['/settings/indexing']">Open Indexing</a>
           <a class="secondary-link" [routerLink]="['/scenes']">Browse Scenes</a>
           @if (pageAlert()) {
-            <a class="secondary-link" [routerLink]="['/settings']">Open Settings</a>
+            <a class="secondary-link" [routerLink]="['/settings/integrations']">
+              Repair integrations
+            </a>
           }
         }
       </div>

--- a/apps/sp-web/src/app/pages/library/library-page.component.spec.ts
+++ b/apps/sp-web/src/app/pages/library/library-page.component.spec.ts
@@ -331,6 +331,12 @@ describe('LibraryPageComponent', () => {
       'Currently showing projected library data synced through',
     );
     expect(degradedAlert?.textContent).toContain('Newly imported scenes');
+    expect(
+      degradedAlert?.querySelector('a[href*="/settings/integrations"]')?.textContent,
+    ).toContain('Repair integrations');
+    expect(degradedAlert?.querySelector('a[href*="/settings/indexing"]')?.textContent).toContain(
+      'Open Indexing',
+    );
   });
 
   it('renders an intentional empty state when the local library has no indexed scenes yet', async () => {
@@ -342,6 +348,9 @@ describe('LibraryPageComponent', () => {
     expect(
       fixture.nativeElement.querySelector('[data-testid="library-empty-state"]')?.textContent,
     ).toContain('Track Imports');
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="library-empty-state"]')?.textContent,
+    ).toContain('Open Indexing');
   });
 
   it('renders a no-match empty state when filters narrow the library to zero scenes', async () => {

--- a/apps/sp-web/src/app/pages/library/library-page.component.ts
+++ b/apps/sp-web/src/app/pages/library/library-page.component.ts
@@ -40,6 +40,11 @@ import {
 } from '../../core/api/library.types';
 import { SceneCardBadge, SceneCardComponent } from '../../shared/scene-card/scene-card.component';
 import { SceneCardShellLink } from '../../shared/scene-card/scene-card-shell.component';
+import {
+  buildReadinessPageAlert,
+  firstUseEmptyStateCopy,
+  initialIndexingGuidance,
+} from '../../shared/readiness/first-run-readiness.utils';
 
 interface MultiSelectOption {
   label: string;
@@ -174,27 +179,25 @@ export class LibraryPageComponent implements OnInit, AfterViewInit, OnDestroy {
   protected readonly tagMatchOptions = LibraryPageComponent.TAG_MATCH_OPTIONS;
   protected readonly localCardBadges = LibraryPageComponent.LOCAL_CARD_BADGES;
   protected readonly pageAlert = computed<LibraryPageAlert | null>(() => {
-    const setupStatus = this.setupStatusStore.status();
-    if (setupStatus && !setupStatus.required.stash) {
-      return {
-        title: 'Local library browsing needs attention',
-        message:
-          'Stash needs repair for this surface. Newly imported scenes, artwork, and local favorite overlays may be missing or stale until the integration is fixed.',
-      };
-    }
-
-    const runtimeStatus = this.runtimeHealthService.status();
-    if (!runtimeStatus?.services.stash.degraded) {
+    const alert = buildReadinessPageAlert(
+      'library',
+      this.setupStatusStore.status(),
+      this.runtimeHealthService.status(),
+    );
+    if (!alert) {
       return null;
     }
 
-    const freshnessHint = this.latestSyncAt()
-      ? `Currently showing projected library data synced through ${this.formatDateTime(this.latestSyncAt())}.`
-      : 'Currently showing projected library data with an unknown sync timestamp.';
+    const freshnessHint =
+      alert.eyebrow === 'Runtime Outage'
+        ? this.latestSyncAt()
+          ? ` Currently showing projected library data synced through ${this.formatDateTime(this.latestSyncAt())}.`
+          : ' Current library sync freshness is unknown.'
+        : '';
 
     return {
-      title: 'Local library freshness is degraded',
-      message: `${freshnessHint} Newly imported scenes, refreshed metadata, and availability overlays may lag until Stash is healthy again.`,
+      title: alert.title,
+      message: `${alert.message}${freshnessHint}`,
     };
   });
 
@@ -379,13 +382,27 @@ export class LibraryPageComponent implements OnInit, AfterViewInit, OnDestroy {
   protected emptyStateTitle(): string {
     return this.hasNarrowingFilters()
       ? 'Nothing matches the current library view'
-      : 'No local scenes are indexed yet';
+      : firstUseEmptyStateCopy('library').title;
   }
 
   protected emptyStateMessage(): string {
-    return this.hasNarrowingFilters()
-      ? 'Clear or adjust the current filters to bring local scenes back into view. If you just imported something, Stash or indexing may still be catching up.'
-      : 'This page only shows scenes that already exist in Stash. Import content, wait for indexing to finish, or browse discovery while your local library catches up.';
+    if (this.hasNarrowingFilters()) {
+      return 'Clear or adjust the current filters to bring local scenes back into view. If you just imported something, Stash or indexing may still be catching up.';
+    }
+
+    if (this.pageAlert()) {
+      return 'Library may be empty because Stash is degraded. Repair the integration, then run Sync All from Indexing & Sync if the local library still has not appeared.';
+    }
+
+    if (this.latestSyncAt()) {
+      return 'Indexing has run, but Stasharr did not find local scenes for this view. Check Stash for imported scenes, then run Sync All after new imports.';
+    }
+
+    return firstUseEmptyStateCopy('library').message;
+  }
+
+  protected indexingGuidance(): string {
+    return initialIndexingGuidance();
   }
 
   protected sortSummaryShort(): string {

--- a/apps/sp-web/src/app/pages/scenes/scenes-page.component.html
+++ b/apps/sp-web/src/app/pages/scenes/scenes-page.component.html
@@ -10,6 +10,23 @@
     }
   </header>
 
+  @if (pageAlert(); as alert) {
+    <section class="page-alert app-page-alert" data-testid="scenes-readiness-alert" role="status">
+      <div class="app-page-alert__copy">
+        <p class="eyebrow">{{ alert.eyebrow }}</p>
+        <h2>{{ alert.title }}</h2>
+        <p>{{ alert.message }}</p>
+      </div>
+
+      <div class="page-alert-actions app-action-row">
+        <a class="state-link primary" [routerLink]="['/settings/integrations']">
+          Repair integrations
+        </a>
+        <a class="state-link" [routerLink]="['/settings/indexing']">Open indexing</a>
+      </div>
+    </section>
+  }
+
   <section class="controls-shell" aria-label="Scenes controls">
     <div class="controls-header">
       <span class="controls-title">Catalog Discovery</span>
@@ -160,7 +177,27 @@
     <p-message severity="error" styleClass="app-page-message">{{ error() }}</p-message>
     <button type="button" class="retry-button" (click)="retryInitialLoad()">Retry</button>
   } @else if (!hasItems()) {
-    <p class="state">{{ emptyStateMessage() }}</p>
+    <section class="empty-shell app-state-block" data-testid="scenes-empty-state">
+      <h2>{{ emptyStateTitle() }}</h2>
+      <p class="app-state-copy">{{ emptyStateMessage() }}</p>
+      @if (!hasActiveFilters()) {
+        <p class="app-state-copy">{{ indexingGuidance() }}</p>
+      }
+
+      <div class="state-actions app-action-row">
+        @if (hasActiveFilters()) {
+          <button type="button" class="state-link primary" (click)="resetFilters()">
+            Clear filters
+          </button>
+        } @else {
+          <a class="state-link primary" [routerLink]="['/settings/indexing']">Open indexing</a>
+          <a class="state-link" [routerLink]="['/library']">Open Library</a>
+        }
+        @if (pageAlert()) {
+          <a class="state-link" [routerLink]="['/settings/integrations']">Repair integrations</a>
+        }
+      </div>
+    </section>
   } @else {
     <section class="grid">
       @for (item of items(); track item.id) {

--- a/apps/sp-web/src/app/pages/scenes/scenes-page.component.scss
+++ b/apps/sp-web/src/app/pages/scenes/scenes-page.component.scss
@@ -21,8 +21,60 @@ header p {
   margin-top: 0.5rem;
 }
 
+.eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
 .state {
   margin-top: 1rem;
+}
+
+.page-alert {
+  margin-top: 0.9rem;
+  --app-alert-radius: 8px;
+}
+
+.page-alert p:last-child {
+  color: var(--text-muted);
+  max-width: 70ch;
+}
+
+.empty-shell {
+  margin-top: 0.9rem;
+  --app-state-radius: 8px;
+}
+
+.state-link {
+  font: inherit;
+  min-height: 2.25rem;
+  padding: 0.42rem 0.72rem;
+  border-radius: 6px;
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  color: var(--button-text);
+  font-size: 0.74rem;
+  font-weight: 700;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.state-link.primary {
+  border-color: var(--tone-info-border);
+  background: var(--tone-info-background);
+  color: var(--tone-info-text);
+}
+
+.state-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .error {

--- a/apps/sp-web/src/app/pages/scenes/scenes-page.component.spec.ts
+++ b/apps/sp-web/src/app/pages/scenes/scenes-page.component.spec.ts
@@ -1,8 +1,13 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 import { DiscoverService } from '../../core/api/discover.service';
 import { SceneExplorerItem, ScenesFeedResponse } from '../../core/api/discover.types';
+import { RuntimeHealthService } from '../../core/api/runtime-health.service';
+import { RuntimeHealthResponse } from '../../core/api/runtime-health.types';
+import { SetupStatusStore } from '../../core/api/setup-status.store';
+import { SetupStatusResponse } from '../../core/api/setup.types';
 import { AppNotificationsService } from '../../core/notifications/app-notifications.service';
 import { ScenesPageComponent } from './scenes-page.component';
 
@@ -40,6 +45,60 @@ function buildFeedResponse(
   };
 }
 
+function buildSetupStatus(
+  overrides: Partial<Omit<SetupStatusResponse, 'required'>> & {
+    required?: Partial<SetupStatusResponse['required']>;
+  } = {},
+): SetupStatusResponse {
+  return {
+    setupComplete: overrides.setupComplete ?? true,
+    required: {
+      stash: true,
+      catalog: true,
+      whisparr: true,
+      ...(overrides.required ?? {}),
+    },
+    catalogProvider: overrides.catalogProvider ?? 'STASHDB',
+  };
+}
+
+const HEALTHY_RUNTIME_HEALTH: RuntimeHealthResponse = {
+  degraded: false,
+  failureThreshold: 3,
+  services: {
+    catalog: {
+      service: 'CATALOG',
+      status: 'HEALTHY',
+      degraded: false,
+      consecutiveFailures: 0,
+      lastHealthyAt: '2026-04-02T00:00:00.000Z',
+      lastFailureAt: null,
+      lastErrorMessage: null,
+      degradedAt: null,
+    },
+    stash: {
+      service: 'STASH',
+      status: 'HEALTHY',
+      degraded: false,
+      consecutiveFailures: 0,
+      lastHealthyAt: '2026-04-02T00:00:00.000Z',
+      lastFailureAt: null,
+      lastErrorMessage: null,
+      degradedAt: null,
+    },
+    whisparr: {
+      service: 'WHISPARR',
+      status: 'HEALTHY',
+      degraded: false,
+      consecutiveFailures: 0,
+      lastHealthyAt: '2026-04-02T00:00:00.000Z',
+      lastFailureAt: null,
+      lastErrorMessage: null,
+      degradedAt: null,
+    },
+  },
+};
+
 describe('ScenesPageComponent', () => {
   beforeEach(() => {
     vi.stubGlobal(
@@ -57,13 +116,28 @@ describe('ScenesPageComponent', () => {
     TestBed.resetTestingModule();
   });
 
-  async function renderPage(initialQueryParams: Record<string, string> = {}) {
+  async function renderPage(
+    initialQueryParams: Record<string, string> = {},
+    options?: {
+      feedResponse?: ScenesFeedResponse;
+      runtimeHealth?: RuntimeHealthResponse;
+      setupStatus?: SetupStatusResponse;
+    },
+  ) {
     const queryParamMap = convertToParamMap(initialQueryParams);
     const queryParamMap$ = new BehaviorSubject(queryParamMap);
     const discoverService = {
-      getScenesFeed: vi.fn().mockReturnValue(of(buildFeedResponse())),
+      getScenesFeed: vi.fn().mockReturnValue(of(options?.feedResponse ?? buildFeedResponse())),
       searchSceneTags: vi.fn().mockReturnValue(of([])),
       searchPerformerStudios: vi.fn().mockReturnValue(of([])),
+    };
+    const runtimeHealthService = {
+      ensureStarted: vi.fn(),
+      status: signal(options?.runtimeHealth ?? HEALTHY_RUNTIME_HEALTH).asReadonly(),
+    };
+    const setupStatusStore = {
+      status: signal(options?.setupStatus ?? buildSetupStatus()),
+      sync: vi.fn(),
     };
     const activatedRoute = {
       queryParamMap: queryParamMap$.asObservable(),
@@ -92,6 +166,14 @@ describe('ScenesPageComponent', () => {
           provide: ActivatedRoute,
           useValue: activatedRoute,
         },
+        {
+          provide: RuntimeHealthService,
+          useValue: runtimeHealthService,
+        },
+        {
+          provide: SetupStatusStore,
+          useValue: setupStatusStore,
+        },
       ],
     }).compileComponents();
 
@@ -103,11 +185,11 @@ describe('ScenesPageComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    return { fixture, discoverService, navigateSpy };
+    return { fixture, discoverService, navigateSpy, runtimeHealthService };
   }
 
   it('initializes the canonical scenes discovery view with TRENDING sort', async () => {
-    const { fixture, discoverService, navigateSpy } = await renderPage();
+    const { fixture, discoverService, navigateSpy, runtimeHealthService } = await renderPage();
     const resetButton = fixture.nativeElement.querySelector(
       '.reset-filters-button',
     ) as HTMLButtonElement | null;
@@ -128,15 +210,16 @@ describe('ScenesPageComponent', () => {
     expect(pageText).not.toContain('Already In Library');
     expect(pageText).not.toContain('Missing From Library');
     expect(pageText).not.toContain('Favorite Tags');
+    expect(runtimeHealthService.ensureStarted).toHaveBeenCalledTimes(1);
   });
 
   it('renders discovery results through the shared scene card and forwards request actions', async () => {
     const { fixture } = await renderPage();
     const component = fixture.componentInstance as any;
     const cards = fixture.nativeElement.querySelectorAll('app-scene-card');
-    const requestButton = fixture.nativeElement.querySelector('.request-cta') as
-      | HTMLButtonElement
-      | null;
+    const requestButton = fixture.nativeElement.querySelector(
+      '.request-cta',
+    ) as HTMLButtonElement | null;
 
     expect(cards).toHaveLength(1);
     expect(component.requestModalOpen()).toBe(false);
@@ -244,5 +327,46 @@ describe('ScenesPageComponent', () => {
       queryParamsHandling: 'merge',
       replaceUrl: true,
     });
+  });
+
+  it('renders first-use guidance when the catalog feed is empty', async () => {
+    const { fixture } = await renderPage(
+      {},
+      {
+        feedResponse: buildFeedResponse([], { total: 0 }),
+      },
+    );
+
+    const emptyState = fixture.nativeElement.querySelector(
+      '[data-testid="scenes-empty-state"]',
+    ) as HTMLElement | null;
+
+    expect(emptyState?.textContent).toContain('No catalog scenes are available yet');
+    expect(emptyState?.textContent).toContain('Catalog browsing does not depend on local indexing');
+    expect(emptyState?.textContent).toContain('Open indexing');
+  });
+
+  it('points users to integration repair when catalog discovery is degraded', async () => {
+    const { fixture } = await renderPage(
+      {},
+      {
+        feedResponse: buildFeedResponse([], { total: 0 }),
+        setupStatus: buildSetupStatus({
+          setupComplete: false,
+          required: {
+            catalog: false,
+          },
+        }),
+      },
+    );
+
+    const alert = fixture.nativeElement.querySelector(
+      '[data-testid="scenes-readiness-alert"]',
+    ) as HTMLElement | null;
+    const repairLink = alert?.querySelector('a[href*="/settings/integrations"]');
+
+    expect(alert?.textContent).toContain('Catalog discovery needs attention');
+    expect(fixture.nativeElement.textContent).toContain('Repair integrations');
+    expect(repairLink).toBeTruthy();
   });
 });

--- a/apps/sp-web/src/app/pages/scenes/scenes-page.component.ts
+++ b/apps/sp-web/src/app/pages/scenes/scenes-page.component.ts
@@ -6,11 +6,12 @@ import {
   OnDestroy,
   OnInit,
   ViewChild,
+  computed,
   inject,
   signal,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import {
   Subject,
   Subscription,
@@ -38,8 +39,15 @@ import {
   SceneTagOption,
   isSceneStatusRequestable,
 } from '../../core/api/discover.types';
+import { RuntimeHealthService } from '../../core/api/runtime-health.service';
+import { SetupStatusStore } from '../../core/api/setup-status.store';
 import { SceneCardComponent } from '../../shared/scene-card/scene-card.component';
 import { SceneRequestModalComponent } from '../../shared/scene-request-modal/scene-request-modal.component';
+import {
+  buildReadinessPageAlert,
+  firstUseEmptyStateCopy,
+  initialIndexingGuidance,
+} from '../../shared/readiness/first-run-readiness.utils';
 
 type FavoritesFilterOption = 'NONE' | SceneFavoritesFilter;
 interface MultiSelectOption {
@@ -65,6 +73,7 @@ interface SelectedStudioChip {
     ProgressSpinner,
     Select,
     MultiSelect,
+    RouterLink,
     SceneCardComponent,
     SceneRequestModalComponent,
   ],
@@ -106,6 +115,8 @@ export class ScenesPageComponent implements OnInit, AfterViewInit, OnDestroy {
   ];
 
   private readonly discoverService = inject(DiscoverService);
+  private readonly runtimeHealthService = inject(RuntimeHealthService);
+  private readonly setupStatusStore = inject(SetupStatusStore);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly studioSearchTerms = new Subject<string>();
@@ -176,8 +187,16 @@ export class ScenesPageComponent implements OnInit, AfterViewInit, OnDestroy {
   protected readonly sortOptions = ScenesPageComponent.SORT_OPTIONS;
   protected readonly favoritesOptions = ScenesPageComponent.FAVORITES_OPTIONS;
   protected readonly tagMatchOptions = ScenesPageComponent.TAG_MATCH_OPTIONS;
+  protected readonly pageAlert = computed(() =>
+    buildReadinessPageAlert(
+      'scenes',
+      this.setupStatusStore.status(),
+      this.runtimeHealthService.status(),
+    ),
+  );
 
   ngOnInit(): void {
+    this.runtimeHealthService.ensureStarted();
     this.setupStudioSearch();
     this.setupTagSearch();
     this.setupUrlStateSync();
@@ -340,9 +359,25 @@ export class ScenesPageComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   protected emptyStateMessage(): string {
+    if (this.hasActiveFilters()) {
+      return 'No scenes match the current filters.';
+    }
+
+    if (this.pageAlert()?.impactedServices.includes('CATALOG')) {
+      return 'The catalog feed may be empty because the configured catalog provider needs repair.';
+    }
+
+    return firstUseEmptyStateCopy('scenes').message;
+  }
+
+  protected emptyStateTitle(): string {
     return this.hasActiveFilters()
-      ? 'No scenes match the current filters.'
-      : 'No trending scenes are available right now.';
+      ? 'No scenes match the current filters'
+      : firstUseEmptyStateCopy('scenes').title;
+  }
+
+  protected indexingGuidance(): string {
+    return initialIndexingGuidance();
   }
 
   protected onTagFilterChanged(nextValue: string | null | undefined): void {

--- a/apps/sp-web/src/app/shared/readiness/first-run-readiness.utils.ts
+++ b/apps/sp-web/src/app/shared/readiness/first-run-readiness.utils.ts
@@ -1,0 +1,203 @@
+import { RuntimeHealthResponse } from '../../core/api/runtime-health.types';
+import { SetupStatusResponse } from '../../core/api/setup.types';
+
+export type ReadinessSurface = 'home' | 'scenes' | 'library' | 'acquisition';
+export type ReadinessService = 'CATALOG' | 'STASH' | 'WHISPARR';
+
+export interface FirstUseEmptyStateCopy {
+  title: string;
+  message: string;
+}
+
+export interface ReadinessPageAlert {
+  eyebrow: string;
+  title: string;
+  message: string;
+  impactedServices: ReadinessService[];
+}
+
+export function setupCompleteSummary(catalogProviderLabel: string): string {
+  return `${catalogProviderLabel} is ready with Stash and Whisparr. Home and Scenes are available now; Library, Acquisition, and status badges get better after the initial indexing sync has run.`;
+}
+
+export function initialIndexingGuidance(): string {
+  return 'Use Indexing & Sync after setup to run Sync All when Library is empty, Acquisition looks stale, or status badges do not reflect Whisparr and Stash yet.';
+}
+
+export function firstUseEmptyStateCopy(surface: ReadinessSurface): FirstUseEmptyStateCopy {
+  switch (surface) {
+    case 'home':
+      return {
+        title: 'Home is waiting for useful scene data',
+        message:
+          'Scenes can be browsed from the catalog now. Run the initial indexing sync if Library rails, acquisition status, or local availability still look empty.',
+      };
+    case 'scenes':
+      return {
+        title: 'No catalog scenes are available yet',
+        message:
+          'Catalog browsing does not depend on local indexing. If this stays empty, check the catalog integration; otherwise use indexing to refresh local Library and status overlays.',
+      };
+    case 'library':
+      return {
+        title: 'No local scenes are indexed yet',
+        message:
+          'Run Sync All from Indexing & Sync to project your Stash library into Stasharr. You can keep browsing Scenes while the local library catches up.',
+      };
+    case 'acquisition':
+      return {
+        title: 'No acquisition activity is indexed yet',
+        message:
+          'Requests begin in Scenes. Run the initial indexing sync if you already have Whisparr activity and this page still looks empty.',
+      };
+  }
+}
+
+export function buildReadinessPageAlert(
+  surface: ReadinessSurface,
+  setupStatus: SetupStatusResponse | null | undefined,
+  runtimeStatus: RuntimeHealthResponse | null | undefined,
+): ReadinessPageAlert | null {
+  const setupImpacts = impactedSetupServices(setupStatus, surface);
+  if (setupImpacts.length > 0) {
+    return alertForImpacts(surface, setupImpacts, 'setup');
+  }
+
+  const runtimeImpacts = impactedRuntimeServices(runtimeStatus, surface);
+  if (runtimeImpacts.length > 0) {
+    return alertForImpacts(surface, runtimeImpacts, 'runtime');
+  }
+
+  return null;
+}
+
+function impactedSetupServices(
+  status: SetupStatusResponse | null | undefined,
+  surface: ReadinessSurface,
+): ReadinessService[] {
+  if (!status) {
+    return [];
+  }
+
+  const services = servicesForSurface(surface);
+  return services.filter((service) => {
+    switch (service) {
+      case 'CATALOG':
+        return !status.required.catalog;
+      case 'STASH':
+        return !status.required.stash;
+      case 'WHISPARR':
+        return !status.required.whisparr;
+    }
+  });
+}
+
+function impactedRuntimeServices(
+  status: RuntimeHealthResponse | null | undefined,
+  surface: ReadinessSurface,
+): ReadinessService[] {
+  if (!status?.degraded) {
+    return [];
+  }
+
+  return servicesForSurface(surface).filter((service) => {
+    switch (service) {
+      case 'CATALOG':
+        return status.services.catalog.degraded;
+      case 'STASH':
+        return status.services.stash.degraded;
+      case 'WHISPARR':
+        return status.services.whisparr.degraded;
+    }
+  });
+}
+
+function servicesForSurface(surface: ReadinessSurface): ReadinessService[] {
+  switch (surface) {
+    case 'home':
+      return ['CATALOG', 'STASH', 'WHISPARR'];
+    case 'scenes':
+      return ['CATALOG', 'STASH', 'WHISPARR'];
+    case 'library':
+      return ['STASH'];
+    case 'acquisition':
+      return ['WHISPARR', 'STASH'];
+  }
+}
+
+function alertForImpacts(
+  surface: ReadinessSurface,
+  impactedServices: ReadinessService[],
+  source: 'setup' | 'runtime',
+): ReadinessPageAlert {
+  const eyebrow = source === 'setup' ? 'Repair Required' : 'Runtime Outage';
+  const services = new Set(impactedServices);
+
+  switch (surface) {
+    case 'home':
+      return {
+        eyebrow,
+        impactedServices,
+        title: 'Home data is degraded',
+        message:
+          'One or more required integrations cannot provide rail data right now. Some Home rails may be empty or stale until integrations are repaired.',
+      };
+    case 'scenes':
+      if (services.has('CATALOG')) {
+        return {
+          eyebrow,
+          impactedServices,
+          title: 'Catalog discovery needs attention',
+          message:
+            'Scenes depends on the configured catalog provider. Results may be empty or stale until the catalog integration is healthy again.',
+        };
+      }
+
+      return {
+        eyebrow,
+        impactedServices,
+        title: 'Scene status overlays are degraded',
+        message:
+          'Catalog browsing can continue, but Whisparr and Stash status badges may be stale until the affected integration is healthy again.',
+      };
+    case 'library':
+      return {
+        eyebrow,
+        impactedServices,
+        title:
+          source === 'setup'
+            ? 'Local library browsing needs attention'
+            : 'Local library freshness is degraded',
+        message:
+          'Library depends on Stash. Newly imported scenes, artwork, local favorites, and availability overlays may be missing or stale until Stash is healthy again.',
+      };
+    case 'acquisition':
+      if (services.has('WHISPARR') && services.has('STASH')) {
+        return {
+          eyebrow,
+          impactedServices,
+          title: 'Acquisition tracking is degraded',
+          message:
+            'Whisparr and Stash both affect this page. Request progress, failure states, and import visibility may be incomplete or stale until both recover.',
+        };
+      }
+
+      if (services.has('WHISPARR')) {
+        return {
+          eyebrow,
+          impactedServices,
+          title: 'Whisparr needs attention',
+          message:
+            'Acquisition progress depends on Whisparr. Queue state, failures, and request progression may be stale until it is healthy again.',
+        };
+      }
+
+      return {
+        eyebrow,
+        impactedServices,
+        title: 'Stash import visibility is degraded',
+        message:
+          'Downloaded scenes may take longer to appear as imported while Stash is unhealthy. Repair integrations if import handoffs look stuck.',
+      };
+  }
+}


### PR DESCRIPTION
- clarify admin bootstrap handoff into setup

- add setup-complete milestone with Home and indexing CTAs

- improve first-use and degraded states across Home, Scenes, Library, and Acquisition

- add targeted frontend tests and GitHub funding metadata