### PR TITLE
feat(runtime): expose built app version metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,4 @@ jobs:
       - name: Build production image
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t stasharr-portal:test .
+        run: docker build --build-arg STASHARR_VERSION=0.0.0-ci -t stasharr-portal:test .

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -51,6 +51,16 @@ jobs:
             org.opencontainers.image.description=Stasharr production app image
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
+      - name: Resolve app version
+        id: app-version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=edge-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push app image
         uses: docker/build-push-action@v7
         with:
@@ -59,3 +69,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            STASHARR_VERSION=${{ steps.app-version.outputs.value }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ Stasharr publishes one production image to GHCR at `ghcr.io/enymawse/stasharr-po
 - Pushes to `main` publish development tags `edge` and `sha-<shortsha>`.
 - Pushes of release tags matching `vX.Y.Z` publish `vX.Y.Z`, `vX.Y`, `vX`, and `latest`.
 - `latest` tracks the newest stable tagged release, not the tip of `main`.
+- Release images bake `STASHARR_VERSION` from the tag without the leading `v`, so tag `v0.1.0` displays app version `0.1.0` in health, About, and Settings Overview.
+- `main` images bake `STASHARR_VERSION=edge-<shortsha>`. Local Docker builds that omit the build arg use `0.0.0-dev`.
 
 The published image is built from the repo-root `Dockerfile`. It installs the workspace, generates the Prisma client, builds the Nest API and Angular frontend, then copies the production runtime artifacts into a separate runtime stage.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,11 @@ FROM node:22-alpine AS runtime
 WORKDIR /app
 RUN apk add --no-cache openssl
 RUN mkdir -p /var/lib/stasharr && chmod 700 /var/lib/stasharr
+ARG STASHARR_VERSION=0.0.0-dev
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000
+ENV STASHARR_VERSION=$STASHARR_VERSION
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/prisma.config.ts ./prisma.config.ts
 COPY --from=build /app/node_modules ./node_modules

--- a/apps/sp-api/src/health/health.controller.spec.ts
+++ b/apps/sp-api/src/health/health.controller.spec.ts
@@ -1,0 +1,61 @@
+import { PrismaService } from '../prisma/prisma.service';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  const originalStasharrVersion = process.env.STASHARR_VERSION;
+  const originalNpmPackageVersion = process.env.npm_package_version;
+
+  const prisma = {
+    $queryRaw: jest.fn().mockResolvedValue([{ result: 1 }]),
+  } as unknown as PrismaService;
+
+  let controller: HealthController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.STASHARR_VERSION;
+    delete process.env.npm_package_version;
+    controller = new HealthController(prisma);
+  });
+
+  afterAll(() => {
+    restoreEnv('STASHARR_VERSION', originalStasharrVersion);
+    restoreEnv('npm_package_version', originalNpmPackageVersion);
+  });
+
+  it('returns STASHARR_VERSION as the app version when it is set', async () => {
+    process.env.STASHARR_VERSION = '9.9.9-test';
+    process.env.npm_package_version = '0.0.1';
+
+    await expect(controller.getStatus()).resolves.toMatchObject({
+      status: 'ok',
+      database: 'ok',
+      service: 'sp-api',
+      version: '9.9.9-test',
+    });
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to npm_package_version when STASHARR_VERSION is unset', async () => {
+    process.env.npm_package_version = '1.2.3-local';
+
+    await expect(controller.getStatus()).resolves.toMatchObject({
+      version: '1.2.3-local',
+    });
+  });
+
+  it('falls back to a dev version when no runtime version is available', async () => {
+    await expect(controller.getStatus()).resolves.toMatchObject({
+      version: '0.0.0-dev',
+    });
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+}

--- a/apps/sp-api/src/health/health.controller.ts
+++ b/apps/sp-api/src/health/health.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get } from '@nestjs/common';
 import { Public } from '../auth/decorators/public.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 
+const DEFAULT_APP_VERSION = '0.0.0-dev';
+
 @Controller('api/v1/status')
 export class HealthController {
   constructor(private readonly prisma: PrismaService) {}
@@ -15,7 +17,20 @@ export class HealthController {
       status: 'ok',
       database: 'ok',
       service: 'sp-api',
-      version: process.env.npm_package_version ?? '0.0.1',
+      version: resolveAppVersion(),
     };
   }
+}
+
+export function resolveAppVersion(): string {
+  return (
+    normalizeVersion(process.env.STASHARR_VERSION) ??
+    normalizeVersion(process.env.npm_package_version) ??
+    DEFAULT_APP_VERSION
+  );
+}
+
+function normalizeVersion(value: string | undefined): string | undefined {
+  const version = value?.trim();
+  return version ? version : undefined;
 }


### PR DESCRIPTION
- wire STASHARR_VERSION build arg into the runtime image

- prefer STASHARR_VERSION in the health endpoint with local fallbacks

- pass release, edge, and CI version metadata through Docker builds