### PR TITLE
fix(sp-api): harden indexing memory behavior

### DIFF
--- a/apps/sp-api/src/indexing/indexing.scheduler.spec.ts
+++ b/apps/sp-api/src/indexing/indexing.scheduler.spec.ts
@@ -1,0 +1,100 @@
+import { Logger } from '@nestjs/common';
+import { IndexingService } from './indexing.service';
+import { IndexingScheduler } from './indexing.scheduler';
+
+function createIndexingServiceMock(): jest.Mocked<
+  Pick<
+    IndexingService,
+    | 'bootstrapIndex'
+    | 'syncWhisparrQueue'
+    | 'syncWhisparrMovies'
+    | 'syncLibraryProjection'
+    | 'syncMetadataBackfill'
+  >
+> {
+  return {
+    bootstrapIndex: jest.fn().mockResolvedValue(null),
+    syncWhisparrQueue: jest.fn().mockResolvedValue(null),
+    syncWhisparrMovies: jest.fn().mockResolvedValue(null),
+    syncLibraryProjection: jest.fn().mockResolvedValue(null),
+    syncMetadataBackfill: jest.fn().mockResolvedValue(null),
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('IndexingScheduler', () => {
+  const originalMemoryLog = process.env.STASHARR_INDEXING_MEMORY_LOG;
+
+  afterEach(() => {
+    if (originalMemoryLog === undefined) {
+      delete process.env.STASHARR_INDEXING_MEMORY_LOG;
+    } else {
+      process.env.STASHARR_INDEXING_MEMORY_LOG = originalMemoryLog;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('skips overlapping runs of the same in-process job', async () => {
+    const debugSpy = jest
+      .spyOn(Logger.prototype, 'debug')
+      .mockImplementation(() => undefined);
+    let releaseFirstRun!: () => void;
+    const firstRun = new Promise<null>((resolve) => {
+      releaseFirstRun = () => resolve(null);
+    });
+    const indexingService = createIndexingServiceMock();
+    indexingService.syncMetadataBackfill.mockReturnValueOnce(firstRun);
+    const scheduler = new IndexingScheduler(
+      indexingService as unknown as IndexingService,
+    );
+
+    scheduler.handleMetadataBackfill();
+    scheduler.handleMetadataBackfill();
+
+    expect(indexingService.syncMetadataBackfill).toHaveBeenCalledTimes(1);
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Skipping overlapping indexing job: metadata-backfill',
+    );
+
+    releaseFirstRun();
+    await firstRun;
+    await flushPromises();
+
+    scheduler.handleMetadataBackfill();
+
+    expect(indexingService.syncMetadataBackfill).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs memory usage for scheduler jobs when enabled', async () => {
+    process.env.STASHARR_INDEXING_MEMORY_LOG = '1';
+    const debugSpy = jest
+      .spyOn(Logger.prototype, 'debug')
+      .mockImplementation(() => undefined);
+    jest.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 101 * 1024 ** 2,
+      heapTotal: 40 * 1024 ** 2,
+      heapUsed: 20 * 1024 ** 2,
+      external: 3 * 1024 ** 2,
+      arrayBuffers: 2 * 1024 ** 2,
+    });
+    const indexingService = createIndexingServiceMock();
+    const scheduler = new IndexingScheduler(
+      indexingService as unknown as IndexingService,
+    );
+
+    scheduler.handleMetadataBackfill();
+    await flushPromises();
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[metadata-backfill] outcome=completed'),
+    );
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('rss=101MB'));
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('heap=20/40MB'),
+    );
+  });
+});

--- a/apps/sp-api/src/indexing/indexing.scheduler.spec.ts
+++ b/apps/sp-api/src/indexing/indexing.scheduler.spec.ts
@@ -97,4 +97,33 @@ describe('IndexingScheduler', () => {
       expect.stringContaining('heap=20/40MB'),
     );
   });
+
+  it('logs failed outcome when a scheduler job rejects', async () => {
+    process.env.STASHARR_INDEXING_MEMORY_LOG = '1';
+    const debugSpy = jest
+      .spyOn(Logger.prototype, 'debug')
+      .mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    jest.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 101 * 1024 ** 2,
+      heapTotal: 40 * 1024 ** 2,
+      heapUsed: 20 * 1024 ** 2,
+      external: 3 * 1024 ** 2,
+      arrayBuffers: 2 * 1024 ** 2,
+    });
+    const indexingService = createIndexingServiceMock();
+    indexingService.syncMetadataBackfill.mockRejectedValueOnce(
+      new Error('metadata failed'),
+    );
+    const scheduler = new IndexingScheduler(
+      indexingService as unknown as IndexingService,
+    );
+
+    scheduler.handleMetadataBackfill();
+    await flushPromises();
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[metadata-backfill] outcome=failed'),
+    );
+  });
 });

--- a/apps/sp-api/src/indexing/indexing.scheduler.ts
+++ b/apps/sp-api/src/indexing/indexing.scheduler.ts
@@ -52,9 +52,11 @@ export class IndexingScheduler implements OnApplicationBootstrap {
 
     this.runningJobs.add(jobName);
     const startedAt = Date.now();
+    let outcome = 'completed';
 
     void task()
       .catch((error: unknown) => {
+        outcome = 'failed';
         this.logger.error(
           `Background indexing job failed: ${jobName}`,
           error instanceof Error ? error.stack : undefined,
@@ -62,7 +64,7 @@ export class IndexingScheduler implements OnApplicationBootstrap {
       })
       .finally(() => {
         this.runningJobs.delete(jobName);
-        this.logMemory(jobName, 'completed', Date.now() - startedAt);
+        this.logMemory(jobName, outcome, Date.now() - startedAt);
       });
   }
 

--- a/apps/sp-api/src/indexing/indexing.scheduler.ts
+++ b/apps/sp-api/src/indexing/indexing.scheduler.ts
@@ -5,6 +5,7 @@ import { IndexingService } from './indexing.service';
 @Injectable()
 export class IndexingScheduler implements OnApplicationBootstrap {
   private readonly logger = new Logger(IndexingScheduler.name);
+  private readonly runningJobs = new Set<string>();
 
   constructor(private readonly indexingService: IndexingService) {}
 
@@ -43,11 +44,52 @@ export class IndexingScheduler implements OnApplicationBootstrap {
   }
 
   private runInBackground(jobName: string, task: () => Promise<unknown>): void {
-    void task().catch((error: unknown) => {
-      this.logger.error(
-        `Background indexing job failed: ${jobName}`,
-        error instanceof Error ? error.stack : undefined,
-      );
-    });
+    if (this.runningJobs.has(jobName)) {
+      this.logger.debug(`Skipping overlapping indexing job: ${jobName}`);
+      this.logMemory(jobName, 'skipped-overlap');
+      return;
+    }
+
+    this.runningJobs.add(jobName);
+    const startedAt = Date.now();
+
+    void task()
+      .catch((error: unknown) => {
+        this.logger.error(
+          `Background indexing job failed: ${jobName}`,
+          error instanceof Error ? error.stack : undefined,
+        );
+      })
+      .finally(() => {
+        this.runningJobs.delete(jobName);
+        this.logMemory(jobName, 'completed', Date.now() - startedAt);
+      });
+  }
+
+  private logMemory(
+    jobName: string,
+    outcome: string,
+    durationMs?: number,
+  ): void {
+    if (!this.isMemoryLoggingEnabled()) {
+      return;
+    }
+
+    const memory = process.memoryUsage();
+    const toMb = (bytes: number) => Math.round(bytes / 1024 ** 2);
+
+    this.logger.debug(
+      `[${jobName}] outcome=${outcome}${
+        durationMs === undefined ? '' : ` durationMs=${durationMs}`
+      } rss=${toMb(memory.rss)}MB heap=${toMb(memory.heapUsed)}/${toMb(
+        memory.heapTotal,
+      )}MB external=${toMb(memory.external)}MB arrayBuffers=${toMb(
+        memory.arrayBuffers,
+      )}MB`,
+    );
+  }
+
+  private isMemoryLoggingEnabled(): boolean {
+    return process.env.STASHARR_INDEXING_MEMORY_LOG === '1';
   }
 }

--- a/apps/sp-api/src/indexing/indexing.service.spec.ts
+++ b/apps/sp-api/src/indexing/indexing.service.spec.ts
@@ -1431,4 +1431,61 @@ describe('IndexingService', () => {
     expect(runWithLeaseMock).not.toHaveBeenCalled();
     expect(getSceneMetadataByIdsMock).not.toHaveBeenCalled();
   });
+
+  it('clears metadata hydration in-flight IDs after a failed metadata batch', async () => {
+    const { prisma, sceneIndexStore } = createPrismaMock({
+      sceneIndexRows: [
+        buildSceneIndexRow({
+          stashId: 'scene-1',
+        }),
+      ],
+    });
+    getSceneMetadataByIdsMock.mockRejectedValueOnce(new Error('network stall'));
+    const service = new IndexingService(
+      prisma,
+      integrationsService,
+      catalogProviderService,
+      whisparrAdapter,
+      stashAdapter,
+      stashdbAdapter,
+      syncStateService,
+    );
+    const internals = service as unknown as {
+      metadataHydrationInFlight: Set<string>;
+    };
+
+    await service.hydrateMetadataForStashIds(['scene-1'], 'test');
+
+    expect(internals.metadataHydrationInFlight.size).toBe(0);
+    expect(sceneIndexStore.get('scene-1')).toEqual(
+      expect.objectContaining({
+        metadataHydrationState: MetadataHydrationState.FAILED_RETRYABLE,
+        metadataRetryAfterAt: expect.any(Date),
+      }),
+    );
+
+    getSceneMetadataByIdsMock.mockResolvedValueOnce([
+      {
+        id: 'scene-1',
+        title: 'Recovered scene',
+        details: null,
+        imageUrl: null,
+        studioId: null,
+        studioName: null,
+        studioImageUrl: null,
+        releaseDate: null,
+        duration: null,
+      },
+    ]);
+
+    await service.hydrateMetadataForStashIds(['scene-1'], 'test-retry');
+
+    expect(getSceneMetadataByIdsMock).toHaveBeenCalledTimes(2);
+    expect(sceneIndexStore.get('scene-1')).toEqual(
+      expect.objectContaining({
+        metadataHydrationState: MetadataHydrationState.HYDRATED,
+        title: 'Recovered scene',
+      }),
+    );
+  });
 });

--- a/apps/sp-api/src/providers/fetch-with-timeout.spec.ts
+++ b/apps/sp-api/src/providers/fetch-with-timeout.spec.ts
@@ -1,0 +1,62 @@
+import { fetchWithTimeout } from './fetch-with-timeout';
+
+describe('fetchWithTimeout', () => {
+  let originalFetch: typeof fetch;
+  const fetchMock: jest.MockedFunction<typeof fetch> = jest.fn();
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+    Object.assign(global, { fetch: fetchMock });
+  });
+
+  afterAll(() => {
+    Object.assign(global, { fetch: originalFetch });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('passes an abort signal to fetch', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response);
+
+    await fetchWithTimeout('http://provider.local/graphql', {
+      method: 'POST',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://provider.local/graphql',
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('aborts a provider request after the timeout', async () => {
+    jest.useFakeTimers();
+    fetchMock.mockImplementation((_input, init) => {
+      const signal = init?.signal as AbortSignal;
+
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      });
+    });
+
+    const request = fetchWithTimeout('http://provider.local/graphql', {}, 25);
+    const expectation = expect(request).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+
+    await jest.advanceTimersByTimeAsync(25);
+    await expectation;
+  });
+});

--- a/apps/sp-api/src/providers/fetch-with-timeout.ts
+++ b/apps/sp-api/src/providers/fetch-with-timeout.ts
@@ -1,0 +1,21 @@
+const DEFAULT_PROVIDER_FETCH_TIMEOUT_MS = 30_000;
+
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  timeoutMs = DEFAULT_PROVIDER_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/sp-api/src/providers/stash/stash.adapter.spec.ts
+++ b/apps/sp-api/src/providers/stash/stash.adapter.spec.ts
@@ -106,6 +106,7 @@ describe('StashAdapter', () => {
           Accept: 'application/json',
           ApiKey: 'secret',
         },
+        signal: expect.any(AbortSignal),
       }),
     );
 
@@ -922,7 +923,10 @@ describe('StashAdapter', () => {
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       'http://stash.local/images/411.jpg',
-      { headers: { ApiKey: 'secret' } },
+      expect.objectContaining({
+        headers: { ApiKey: 'secret' },
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 

--- a/apps/sp-api/src/providers/stash/stash.adapter.ts
+++ b/apps/sp-api/src/providers/stash/stash.adapter.ts
@@ -7,6 +7,7 @@ import {
   normalizeCatalogSceneRefs,
 } from '../catalog/catalog-provider.util';
 import { RuntimeHealthService } from '../../runtime-health/runtime-health.service';
+import { fetchWithTimeout } from '../fetch-with-timeout';
 
 export interface StashAdapterBaseConfig {
   baseUrl: string;
@@ -702,7 +703,7 @@ export class StashAdapter {
 
     let response: Response;
     try {
-      response = await fetch(resolvedUrl, { headers });
+      response = await fetchWithTimeout(resolvedUrl, { headers });
     } catch (error) {
       await this.reportRuntimeFailure(error);
       throw new BadGatewayException('Failed to reach Stash provider endpoint.');
@@ -1231,7 +1232,7 @@ export class StashAdapter {
 
     let response: Response;
     try {
-      response = await fetch(endpoint, {
+      response = await fetchWithTimeout(endpoint, {
         method: 'POST',
         headers,
         body: JSON.stringify({ query, variables }),

--- a/apps/sp-api/src/providers/stashdb/stashdb.adapter.ts
+++ b/apps/sp-api/src/providers/stashdb/stashdb.adapter.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { RuntimeHealthServiceKey } from '@prisma/client';
 import { RuntimeHealthService } from '../../runtime-health/runtime-health.service';
+import { fetchWithTimeout } from '../fetch-with-timeout';
 
 export interface StashdbAdapterBaseConfig {
   baseUrl: string;
@@ -2037,7 +2038,7 @@ export class StashdbAdapter {
 
     let response: Response;
     try {
-      response = await fetch(endpoint, {
+      response = await fetchWithTimeout(endpoint, {
         method: 'POST',
         headers,
         body: JSON.stringify({

--- a/apps/sp-api/src/providers/whisparr/whisparr.adapter.spec.ts
+++ b/apps/sp-api/src/providers/whisparr/whisparr.adapter.spec.ts
@@ -71,13 +71,14 @@ describe('WhisparrAdapter', () => {
 
       expect(fetchMock).toHaveBeenCalledWith(
         'http://whisparr.local/base/api/v3/movie?stashId=scene-1',
-        {
+        expect.objectContaining({
           method: 'GET',
           headers: {
             Accept: 'application/json',
             'X-Api-Key': 'secret',
           },
-        },
+          signal: expect.any(AbortSignal),
+        }),
       );
       expect(runtimeHealthService.recordSuccess).toHaveBeenCalledWith(
         'WHISPARR',
@@ -183,13 +184,14 @@ describe('WhisparrAdapter', () => {
 
       expect(fetchMock).toHaveBeenCalledWith(
         'http://whisparr.local/base/api/v3/movie/42',
-        {
+        expect.objectContaining({
           method: 'GET',
           headers: {
             Accept: 'application/json',
             'X-Api-Key': 'secret',
           },
-        },
+          signal: expect.any(AbortSignal),
+        }),
       );
     });
 
@@ -459,24 +461,28 @@ describe('WhisparrAdapter', () => {
         ),
       ).resolves.toEqual({ movieId: 777 });
 
-      expect(fetchMock).toHaveBeenCalledWith('http://whisparr.local/api/v3/movie', {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-          'X-Api-Key': 'secret',
-        },
-        body: JSON.stringify({
-          title: 'Scene title',
-          studio: 'Scene studio',
-          foreignId: 'scene-1',
-          monitored: true,
-          rootFolderPath: '/media/a',
-          addOptions: { searchForMovie: true },
-          qualityProfileId: 10,
-          tags: [50],
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://whisparr.local/api/v3/movie',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            'X-Api-Key': 'secret',
+          },
+          body: JSON.stringify({
+            title: 'Scene title',
+            studio: 'Scene studio',
+            foreignId: 'scene-1',
+            monitored: true,
+            rootFolderPath: '/media/a',
+            addOptions: { searchForMovie: true },
+            qualityProfileId: 10,
+            tags: [50],
+          }),
+          signal: expect.any(AbortSignal),
         }),
-      });
+      );
     });
 
     it('throws for malformed create movie response payload', async () => {

--- a/apps/sp-api/src/providers/whisparr/whisparr.adapter.ts
+++ b/apps/sp-api/src/providers/whisparr/whisparr.adapter.ts
@@ -1,6 +1,7 @@
 import { BadGatewayException, Injectable, Logger } from '@nestjs/common';
 import { RuntimeHealthServiceKey } from '@prisma/client';
 import { RuntimeHealthService } from '../../runtime-health/runtime-health.service';
+import { fetchWithTimeout } from '../fetch-with-timeout';
 
 export interface WhisparrAdapterBaseConfig {
   baseUrl: string;
@@ -526,7 +527,7 @@ export class WhisparrAdapter {
 
     let response: Response;
     try {
-      response = await fetch(endpoint, {
+      response = await fetchWithTimeout(endpoint, {
         method,
         headers,
         body: body !== undefined ? JSON.stringify(body) : undefined,


### PR DESCRIPTION
- prevent overlapping in-process scheduler jobs

- add opt-in scheduler memory telemetry

- abort hung provider fetches with a shared timeout

relates to #17 