### PR TITLE
fix(stashdb): surface provider network timeout details

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ services:
       # Optional advanced override. Leave unset to let Stasharr generate and persist
       # a unique session secret for this install in the app data volume.
       # SESSION_SECRET: your-own-long-random-secret
+      # Optional: uncomment if catalog provider checks time out on IPv4-only Docker networks.
+      # NODE_OPTIONS: --no-network-family-autoselection
       # Optional: set to true when serving Stasharr over HTTPS.
       SESSION_COOKIE_SECURE: "false"
     ports:
@@ -92,6 +94,9 @@ docker compose up -d
 Open `http://localhost:3000`.
 
 On the first visit, Stasharr opens a bootstrap screen until you create the single local admin account. After that, unauthenticated visits land on the login screen and normal app and API usage require that session.
+
+If StashDB or FansDB Save & Test repeatedly fails with `ETIMEDOUT` on an IPv4-only Docker network, add
+`NODE_OPTIONS: --no-network-family-autoselection` to the app service environment and restart the container.
 
 Tag guidance:
 

--- a/apps/sp-api/src/providers/stashdb/stashdb.adapter.spec.ts
+++ b/apps/sp-api/src/providers/stashdb/stashdb.adapter.spec.ts
@@ -38,10 +38,34 @@ describe('StashdbAdapter', () => {
       adapter.testConnection({
         baseUrl: 'http://stashdb.local/graphql',
       }),
-    ).rejects.toBeInstanceOf(BadGatewayException);
+    ).rejects.toThrow(
+      'Failed to reach StashDB provider endpoint: network failure',
+    );
 
     expect(runtimeHealthService.recordFailure).not.toHaveBeenCalled();
     expect(runtimeHealthService.recordSuccess).not.toHaveBeenCalled();
+  });
+
+  it('preserves nested Node fetch timeout causes in connectivity errors', async () => {
+    const timeout = Object.assign(
+      new Error('connect ETIMEDOUT 2606:4700::6810:85e5:443'),
+      {
+        code: 'ETIMEDOUT',
+      },
+    );
+    const aggregateError = new AggregateError([timeout], 'fetch failed');
+    const fetchError = new TypeError('fetch failed', {
+      cause: aggregateError,
+    });
+    fetchMock.mockRejectedValue(fetchError);
+
+    await expect(
+      adapter.testConnection({
+        baseUrl: 'http://stashdb.local/graphql',
+      }),
+    ).rejects.toThrow(
+      'Failed to reach StashDB provider endpoint: fetch failed; ETIMEDOUT connect ETIMEDOUT 2606:4700::6810:85e5:443',
+    );
   });
 
   it('requests studio images and normalizes studio badge URL from the widest image', async () => {
@@ -379,7 +403,7 @@ describe('StashdbAdapter', () => {
 
     expect(runtimeHealthService.recordFailure).toHaveBeenCalledWith(
       'CATALOG',
-      expect.any(Error),
+      'Failed to reach StashDB provider endpoint: network failure',
     );
   });
 

--- a/apps/sp-api/src/providers/stashdb/stashdb.adapter.ts
+++ b/apps/sp-api/src/providers/stashdb/stashdb.adapter.ts
@@ -2047,12 +2047,11 @@ export class StashdbAdapter {
         }),
       });
     } catch (error) {
+      const message = this.providerRequestFailureMessage(error);
       if (trackRuntimeHealth) {
-        await this.reportRuntimeFailure(error);
+        await this.reportRuntimeFailure(message);
       }
-      throw new BadGatewayException(
-        'Failed to reach StashDB provider endpoint.',
-      );
+      throw new BadGatewayException(message);
     }
 
     if (!response.ok) {
@@ -2102,6 +2101,109 @@ export class StashdbAdapter {
     }
 
     return 'unknown error';
+  }
+
+  private providerRequestFailureMessage(error: unknown): string {
+    const details = this.networkErrorDetails(error);
+
+    if (!details) {
+      return 'Failed to reach StashDB provider endpoint.';
+    }
+
+    return `Failed to reach StashDB provider endpoint: ${details}`;
+  }
+
+  private networkErrorDetails(error: unknown): string | null {
+    const details: string[] = [];
+    this.collectNetworkErrorDetails(error, details, new Set<unknown>());
+
+    return details.length > 0 ? details.join('; ') : null;
+  }
+
+  private collectNetworkErrorDetails(
+    error: unknown,
+    details: string[],
+    seen: Set<unknown>,
+  ): void {
+    if (!error || seen.has(error)) {
+      return;
+    }
+
+    seen.add(error);
+
+    if (typeof error === 'string') {
+      const trimmed = error.trim();
+      if (trimmed.length > 0) {
+        this.addUniqueDetail(details, trimmed);
+      }
+      return;
+    }
+
+    if (error instanceof AggregateError) {
+      for (const nestedError of error.errors) {
+        this.collectNetworkErrorDetails(nestedError, details, seen);
+      }
+    }
+
+    if (error instanceof Error) {
+      const parts = [
+        this.errorCode(error),
+        error.message.trim().length > 0 ? error.message.trim() : null,
+      ].filter((part): part is string => !!part);
+
+      if (parts.length > 0) {
+        this.addUniqueDetail(details, parts.join(' '));
+      }
+
+      this.collectNetworkErrorDetails(error.cause, details, seen);
+      return;
+    }
+
+    if (typeof error === 'object') {
+      const maybeError = error as {
+        cause?: unknown;
+        code?: unknown;
+        message?: unknown;
+        errors?: unknown;
+      };
+      const code =
+        typeof maybeError.code === 'string' && maybeError.code.trim().length > 0
+          ? maybeError.code.trim()
+          : null;
+      const message =
+        typeof maybeError.message === 'string' &&
+        maybeError.message.trim().length > 0
+          ? maybeError.message.trim()
+          : null;
+
+      if (code || message) {
+        this.addUniqueDetail(
+          details,
+          [code, message].filter((part): part is string => !!part).join(' '),
+        );
+      }
+
+      if (Array.isArray(maybeError.errors)) {
+        for (const nestedError of maybeError.errors) {
+          this.collectNetworkErrorDetails(nestedError, details, seen);
+        }
+      }
+
+      this.collectNetworkErrorDetails(maybeError.cause, details, seen);
+    }
+  }
+
+  private errorCode(error: Error): string | null {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' && code.trim().length > 0
+      ? code.trim()
+      : null;
+  }
+
+  private addUniqueDetail(details: string[], detail: string): void {
+    if (!details.includes(detail)) {
+      details.push(detail);
+    }
   }
 
   private resolveGraphqlEndpoint(baseUrl: string): string {

--- a/infrastructure/compose/.env.example
+++ b/infrastructure/compose/.env.example
@@ -8,6 +8,8 @@ HOST=0.0.0.0
 PORT=3000
 DATABASE_MIGRATION_MAX_ATTEMPTS=30
 DATABASE_MIGRATION_RETRY_DELAY_SECONDS=2
+# Optional: uncomment if catalog provider checks time out on IPv4-only Docker networks.
+# NODE_OPTIONS=--no-network-family-autoselection
 # Optional advanced override. Leave unset to let Stasharr generate and persist
 # a unique session secret for this install in the app data volume.
 # SESSION_SECRET=change-this-session-secret

--- a/infrastructure/compose/compose.example.yaml
+++ b/infrastructure/compose/compose.example.yaml
@@ -38,6 +38,8 @@ services:
       # Optional advanced override. Leave unset to let Stasharr generate and persist
       # a unique session secret for this install in the app data volume.
       # SESSION_SECRET: your-own-long-random-secret
+      # Optional: uncomment if catalog provider checks time out on IPv4-only Docker networks.
+      # NODE_OPTIONS: --no-network-family-autoselection
       # Optional: set to true when serving Stasharr over HTTPS.
       SESSION_COOKIE_SECURE: "false"
     ports:


### PR DESCRIPTION
Preserve nested Node fetch causes when StashDB requests fail so Save & Test reports ETIMEDOUT instead of a generic provider error.

Document the NODE_OPTIONS IPv4-only Docker workaround for affected deployments.

fix #24 