### PR TITLE
fix(sp-api): avoid retained prisma batch query strings

### DIFF
--- a/apps/sp-api/src/indexing/indexing.service.spec.ts
+++ b/apps/sp-api/src/indexing/indexing.service.spec.ts
@@ -17,6 +17,28 @@ import { SyncStateService } from './sync-state.service';
 type SceneIndexRow = Record<string, unknown>;
 type LibrarySceneIndexRow = Record<string, unknown>;
 type TransactionOperation = Promise<unknown> | (() => Promise<unknown>);
+type TransactionCallback = (tx: {
+  sceneIndex: {
+    upsert: (args: {
+      where: { stashId: string };
+      create: SceneIndexRow;
+      update: SceneIndexRow;
+    }) => Promise<unknown>;
+  };
+  librarySceneIndex: {
+    upsert: (args: {
+      where: { stashSceneId: string };
+      create: LibrarySceneIndexRow;
+      update: LibrarySceneIndexRow;
+    }) => Promise<unknown>;
+  };
+  sceneIndexSummary: {
+    update: (args: {
+      where: { key: string };
+      data: Record<string, unknown>;
+    }) => Promise<unknown>;
+  };
+}) => Promise<unknown>;
 
 function buildSceneIndexRow(
   overrides: Record<string, unknown> = {},
@@ -487,12 +509,30 @@ function createPrismaMock(config: {
       sceneIndexSummary,
       request,
       syncState,
-      $transaction: jest.fn(async (operations: TransactionOperation[]) =>
-        Promise.all(
-          operations.map((operation) =>
-            typeof operation === 'function' ? operation() : operation,
-          ),
-        ),
+      $transaction: jest.fn(
+        async (
+          operationsOrCallback: TransactionOperation[] | TransactionCallback,
+        ) => {
+          if (typeof operationsOrCallback === 'function') {
+            return operationsOrCallback({
+              sceneIndex: {
+                upsert: async (args) => sceneIndex.upsert(args)(),
+              },
+              librarySceneIndex: {
+                upsert: async (args) => librarySceneIndex.upsert(args)(),
+              },
+              sceneIndexSummary: {
+                update: async (args) => sceneIndexSummary.update(args)(),
+              },
+            });
+          }
+
+          return Promise.all(
+            operationsOrCallback.map((operation) =>
+              typeof operation === 'function' ? operation() : operation,
+            ),
+          );
+        },
       ),
     } as unknown as PrismaService,
     sceneIndexStore,
@@ -1451,9 +1491,11 @@ describe('IndexingService', () => {
         lastSuccessAt: new Date(Date.now() - 5 * 60_000),
       },
     });
-    const sceneIndex = (prisma as unknown as {
-      sceneIndex: { count: jest.Mock };
-    }).sceneIndex;
+    const sceneIndex = (
+      prisma as unknown as {
+        sceneIndex: { count: jest.Mock };
+      }
+    ).sceneIndex;
     const service = new IndexingService(
       prisma,
       integrationsService,

--- a/apps/sp-api/src/indexing/indexing.service.spec.ts
+++ b/apps/sp-api/src/indexing/indexing.service.spec.ts
@@ -17,6 +17,10 @@ import { SyncStateService } from './sync-state.service';
 type SceneIndexRow = Record<string, unknown>;
 type LibrarySceneIndexRow = Record<string, unknown>;
 type TransactionOperation = Promise<unknown> | (() => Promise<unknown>);
+type TransactionOptions = {
+  maxWait?: number;
+  timeout?: number;
+};
 type TransactionCallback = (tx: {
   sceneIndex: {
     upsert: (args: {
@@ -39,6 +43,27 @@ type TransactionCallback = (tx: {
     }) => Promise<unknown>;
   };
 }) => Promise<unknown>;
+
+function expectInteractiveTransactionsToUseIndexWriteOptions(
+  prisma: PrismaService,
+): void {
+  const transaction = (
+    prisma as unknown as {
+      $transaction: jest.Mock;
+    }
+  ).$transaction;
+  const interactiveCalls = transaction.mock.calls.filter(
+    ([operation]) => typeof operation === 'function',
+  );
+
+  expect(interactiveCalls.length).toBeGreaterThan(0);
+  for (const [, options] of interactiveCalls) {
+    expect(options).toEqual({
+      maxWait: 10_000,
+      timeout: 60_000,
+    });
+  }
+}
 
 function buildSceneIndexRow(
   overrides: Record<string, unknown> = {},
@@ -512,6 +537,7 @@ function createPrismaMock(config: {
       $transaction: jest.fn(
         async (
           operationsOrCallback: TransactionOperation[] | TransactionCallback,
+          _options?: TransactionOptions,
         ) => {
           if (typeof operationsOrCallback === 'function') {
             return operationsOrCallback({
@@ -801,6 +827,7 @@ describe('IndexingService', () => {
         computedLifecycle: 'IMPORT_PENDING',
       }),
     );
+    expectInteractiveTransactionsToUseIndexWriteOptions(prisma);
   });
 
   it('syncs the local-library projection and reconciles linked stash availability', async () => {
@@ -965,6 +992,7 @@ describe('IndexingService', () => {
         computedLifecycle: 'NOT_REQUESTED',
       }),
     );
+    expectInteractiveTransactionsToUseIndexWriteOptions(prisma);
   });
 
   it('does not treat an inactive-provider raw id as locally available during library projection', async () => {

--- a/apps/sp-api/src/indexing/indexing.service.ts
+++ b/apps/sp-api/src/indexing/indexing.service.ts
@@ -1615,34 +1615,32 @@ export class IndexingService {
             queueItemsByStashId?.get(patch.stashId),
           ),
         );
-        const transactionOperations: Prisma.PrismaPromise<unknown>[] =
-          nextRows.map((data) =>
-            this.prisma.sceneIndex.upsert({
-              where: {
-                stashId: data.stashId,
-              },
-              create: data,
-              update: data,
-            }),
-          );
         const summaryDelta = this.buildSceneIndexSummaryDelta(
           chunk,
           nextRows,
           existingByStashId,
         );
 
-        if (this.hasSummaryDelta(summaryDelta)) {
-          transactionOperations.push(
-            this.prisma.sceneIndexSummary.update({
+        await this.prisma.$transaction(async (tx) => {
+          for (const data of nextRows) {
+            await tx.sceneIndex.upsert({
+              where: {
+                stashId: data.stashId,
+              },
+              create: data,
+              update: data,
+            });
+          }
+
+          if (this.hasSummaryDelta(summaryDelta)) {
+            await tx.sceneIndexSummary.update({
               where: {
                 key: SCENE_INDEX_SUMMARY_KEY,
               },
               data: this.buildSceneIndexSummaryDeltaUpdate(summaryDelta),
-            }),
-          );
-        }
-
-        await this.prisma.$transaction(transactionOperations);
+            });
+          }
+        });
 
         for (const row of nextRows) {
           existingByStashId.set(row.stashId, row as SceneIndex);
@@ -2243,9 +2241,9 @@ export class IndexingService {
       return 0;
     }
 
-    await this.prisma.$transaction(
-      items.map((item) =>
-        this.prisma.librarySceneIndex.upsert({
+    await this.prisma.$transaction(async (tx) => {
+      for (const item of items) {
+        await tx.librarySceneIndex.upsert({
           where: {
             stashSceneId: item.id,
           },
@@ -2296,9 +2294,9 @@ export class IndexingService {
             hasFavoriteTag: item.hasFavoriteTag,
             lastSyncedAt: syncedAt,
           },
-        }),
-      ),
-    );
+        });
+      }
+    });
 
     return items.length;
   }

--- a/apps/sp-api/src/indexing/indexing.service.ts
+++ b/apps/sp-api/src/indexing/indexing.service.ts
@@ -159,6 +159,8 @@ export class IndexingService {
   private static readonly METADATA_SCHEDULED_CHECK_CACHE_MS = 60_000;
   private static readonly METADATA_RETRY_BACKOFF_MS = 5 * 60_000;
   private static readonly UPSERT_DEADLOCK_RETRY_ATTEMPTS = 3;
+  private static readonly INDEX_WRITE_TRANSACTION_MAX_WAIT_MS = 10_000;
+  private static readonly INDEX_WRITE_TRANSACTION_TIMEOUT_MS = 60_000;
   private static readonly BOOTSTRAP_LEASE_MS = 20 * 60_000;
   private static readonly QUEUE_LEASE_MS = 25_000;
   private static readonly MOVIES_LEASE_MS = 4 * 60_000;
@@ -1640,7 +1642,7 @@ export class IndexingService {
               data: this.buildSceneIndexSummaryDeltaUpdate(summaryDelta),
             });
           }
-        });
+        }, this.indexWriteTransactionOptions());
 
         for (const row of nextRows) {
           existingByStashId.set(row.stashId, row as SceneIndex);
@@ -2296,7 +2298,7 @@ export class IndexingService {
           },
         });
       }
-    });
+    }, this.indexWriteTransactionOptions());
 
     return items.length;
   }
@@ -2584,6 +2586,13 @@ export class IndexingService {
         : new Date(retryAfterAt).getTime();
 
     return Number.isFinite(retryAfterTime) && retryAfterTime <= Date.now();
+  }
+
+  private indexWriteTransactionOptions(): { maxWait: number; timeout: number } {
+    return {
+      maxWait: IndexingService.INDEX_WRITE_TRANSACTION_MAX_WAIT_MS,
+      timeout: IndexingService.INDEX_WRITE_TRANSACTION_TIMEOUT_MS,
+    };
   }
 
   private pickValue<T>(incoming: T | undefined, existing: T): T {


### PR DESCRIPTION
- switch hot scene index upsert paths to interactive transactions

- preserve chunk/page transaction boundaries without building array batches

- update indexing service test prisma mock for interactive transactions

fix #17 